### PR TITLE
fix: Remove Codex OAuth workaround, add install retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2025-01-20
+
+### Changed
+- Removed Codex OAuth workaround (Page 6 in setup wizard) - OpenAI fixed native Docker OAuth support ([#2798](https://github.com/openai/codex/issues/2798))
+- Removed Codex auth auto-sync from launch script - no longer needed
+- Users can now authenticate Codex directly in container with `codex auth login`
+
+### Added
+- Retry logic with cache clearing for npm package installations
+- Handles ECONNRESET errors for large packages like @openai/codex (~100MB)
+- 3 retry attempts with npm cache clean between failures
+- Retry logic for pip package installations
+- Versioning requirements documentation in CLAUDE.md
+
+### Fixed
+- Codex CLI installation failures due to transient network errors during first-time setup
+
+## [1.1.0] - 2025-01-17
+
+### Added
+- Vibe Kanban integration for parallel AI agent orchestration
+- "Launch Vibe Kanban" button in main menu
+- Vibe Kanban auto-installation during first-time setup
+- Port 5173 exposure for Vibe Kanban web interface
+- Diagnostic logging for Vibe Kanban startup
+
+### Changed
+- Improved UI flow and button layout
+- Consolidated AppData folders into single AI-Docker-CLI directory
+
+### Fixed
+- First Time Setup page minimization on startup
+- Force rebuild now uses --no-cache flag
+- Error handling for missing .env file
+
 ## [1.0.1] - 2025-12-11
 
 ### Added
@@ -55,9 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Description |
 |---------|------|-------------|
+| 1.1.1 | 2025-01-20 | Remove Codex OAuth workaround, add install retry logic |
+| 1.1.0 | 2025-01-17 | Vibe Kanban integration |
 | 1.0.1 | 2025-12-11 | Add version display and Report Issue link |
 | 1.0.0 | 2025-12-11 | Initial production release |
 
-[Unreleased]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Cainmani/ai-docker-cli-setup/releases/tag/v1.0.0

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -61,7 +61,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.1.0"
+$script:AppVersion = "1.1.1"
 $script:GitHubRepo = "Cainmani/ai-docker-cli-setup"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -38,7 +38,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.1.0"
+$script:AppVersion = "1.1.1"
 $script:GitHubRepo = "Cainmani/ai-docker-cli-setup"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/setup_wizard.ps1
+++ b/scripts/setup_wizard.ps1
@@ -862,459 +862,30 @@ $p5.Controls.Add($script:terminalBox)
 
 $pages += $p5
 
-# Page 6: Codex Subscription Auth (Optional)
+# Page 6: Done
 $p6 = New-PanelPage
 $p6.Controls.Add((New-Label -text '==================================================================================' -x 20 -y 10 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
-$p6.Controls.Add((New-Label -text 'CODEX SUBSCRIPTION AUTHENTICATION (OPTIONAL)' -x 20 -y 30 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
+$p6.Controls.Add((New-Label -text 'SETUP COMPLETE - YOUR AI ENVIRONMENT IS READY!' -x 20 -y 30 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
 $p6.Controls.Add((New-Label -text '==================================================================================' -x 20 -y 50 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
 $p6.Controls.Add((New-Label '' 20 75 880 24 10 $false $true))
-$p6.Controls.Add((New-Label 'Codex CLI can use your ChatGPT Plus/Pro subscription (no API credits needed).' 20 95 880 24 10 $false $true))
-$p6.Controls.Add((New-Label '' 20 115 880 24 10 $false $true))
-$p6.Controls.Add((New-Label 'This step will:' 20 135 880 24 10 $true $true))
-$p6.Controls.Add((New-Label '  1. Temporarily install Codex on Windows' 20 155 880 24 9 $false $true))
-$p6.Controls.Add((New-Label '  2. Open your browser to sign in with your OpenAI account' 20 175 880 24 9 $false $true))
-$p6.Controls.Add((New-Label '  3. Copy your authentication to the Docker container' 20 195 880 24 9 $false $true))
-$p6.Controls.Add((New-Label '  4. Ask if you want to keep or remove Codex from Windows' 20 215 880 24 9 $false $true))
-$p6.Controls.Add((New-Label '' 20 240 880 24 10 $false $true))
-
-# Status label for Codex setup
-$script:lblCodexStatus = New-Label 'Click "Setup Codex Auth" to begin, or "Skip" to continue without Codex.' 20 265 880 30 10 $true $true
-$p6.Controls.Add($script:lblCodexStatus)
-
-# Terminal box for Codex setup output (reduced height to fit buttons above progress bar)
-$script:codexTerminalBox = New-Object System.Windows.Forms.RichTextBox
-$script:codexTerminalBox.Left = 20
-$script:codexTerminalBox.Top = 300
-$script:codexTerminalBox.Width = 880
-$script:codexTerminalBox.Height = 150
-$script:codexTerminalBox.BackColor = [System.Drawing.Color]::Black
-$script:codexTerminalBox.ForeColor = $script:MatrixGreen
-$script:codexTerminalBox.Font = New-Object System.Drawing.Font('Consolas', 9)
-$script:codexTerminalBox.ReadOnly = $true
-$script:codexTerminalBox.ScrollBars = 'Vertical'
-$script:codexTerminalBox.BorderStyle = 'FixedSingle'
-$script:codexTerminalBox.Text = ">> Waiting for user action...`r`n"
-$p6.Controls.Add($script:codexTerminalBox)
-
-# Setup Codex button (positioned below terminal, above progress bar)
-$btnSetupCodex = New-Button 'Setup Codex Auth' 300 460 180 35
-$btnSetupCodex.BackColor = [System.Drawing.Color]::FromArgb(0, 60, 20)
-$p6.Controls.Add($btnSetupCodex)
-
-# Skip button
-$btnSkipCodex = New-Button 'Skip' 500 460 100 35
-$p6.Controls.Add($btnSkipCodex)
-
-# Track if Codex setup was completed or skipped
-$script:codexSetupDone = $false
-
-$btnSkipCodex.Add_Click({
-    $script:codexSetupDone = $true
-    $script:lblCodexStatus.Text = 'Codex setup skipped. You can configure it later with: configure-tools --codex'
-    $script:codexTerminalBox.AppendText(">> Skipped Codex authentication setup`r`n")
-    Write-Host "[INFO] User skipped Codex authentication" -ForegroundColor Yellow
-    # Auto-advance to next page
-    $script:current++
-    Show-Page $script:current
-})
-
-$btnSetupCodex.Add_Click({
-    $script:codexTerminalBox.Text = ">> Starting Codex authentication setup...`r`n"
-    $script:lblCodexStatus.Text = 'Validating Node.js/npm installation...'
-    $script:lblCodexStatus.ForeColor = $script:MatrixGreen  # Reset color
-    [System.Windows.Forms.Application]::DoEvents()
-
-    # Validate npm is working correctly (not just that it exists)
-    $script:codexTerminalBox.AppendText(">> Validating npm installation...`r`n")
-    [System.Windows.Forms.Application]::DoEvents()
-    $npmCheck = Test-NpmFunctional
-
-    if (-not $npmCheck.Valid) {
-        $errorMessage = $npmCheck.Error
-
-        # Check if npm needs repair vs fresh install
-        if ($npmCheck.NeedsRepair) {
-            $script:codexTerminalBox.AppendText("[WARNING] npm exists but is not functioning correctly`r`n")
-            $script:codexTerminalBox.AppendText("[WARNING] Error: $errorMessage`r`n")
-            $script:codexTerminalBox.AppendText("`r`n>> Attempting to repair npm...`r`n")
-            [System.Windows.Forms.Application]::DoEvents()
-
-            $repairResult = Repair-NpmInstallation
-            if ($repairResult.Valid) {
-                $script:codexTerminalBox.AppendText("[OK] npm repair successful!`r`n")
-                $npmCheck = $repairResult
-            } else {
-                $script:codexTerminalBox.AppendText("[ERROR] npm repair failed`r`n")
-                $script:codexTerminalBox.AppendText("[INFO] Please reinstall Node.js from nodejs.org`r`n")
-                $script:lblCodexStatus.Text = 'npm repair failed. Please reinstall Node.js.'
-                $script:lblCodexStatus.ForeColor = [System.Drawing.Color]::Red
-
-                if (-not $script:IsDevMode) {
-                    Start-Process "https://nodejs.org/"
-                }
-                return
-            }
-        } else {
-            # npm not installed at all
-            $script:codexTerminalBox.AppendText("[ERROR] Node.js/npm is not installed on Windows`r`n")
-            Write-Host "[ERROR] npm not found - Node.js not installed" -ForegroundColor Red
-
-            # Offer to auto-install Node.js (skip in DEV MODE)
-            if (-not $script:IsDevMode) {
-                $installResult = [System.Windows.Forms.MessageBox]::Show(
-                    "Node.js is required but not installed.`n`n" +
-                    "Would you like to install Node.js automatically using winget?`n`n" +
-                    "Click 'Yes' to install automatically`n" +
-                    "Click 'No' to install manually from nodejs.org",
-                    "Install Node.js?",
-                    [System.Windows.Forms.MessageBoxButtons]::YesNo,
-                    [System.Windows.Forms.MessageBoxIcon]::Question
-                )
-            } else {
-                Write-Host "[DEV MODE] Skipping Node.js install popup - assuming Yes" -ForegroundColor Magenta
-                $installResult = [System.Windows.Forms.DialogResult]::Yes
-            }
-
-            if ($installResult -eq [System.Windows.Forms.DialogResult]::Yes) {
-                $script:codexTerminalBox.AppendText("`r`n>> Installing Node.js via winget...`r`n")
-                $script:lblCodexStatus.Text = 'Installing Node.js (this may take a minute)...'
-                [System.Windows.Forms.Application]::DoEvents()
-
-                try {
-                    # Try winget first
-                    $wingetCheck = Get-Command winget -ErrorAction SilentlyContinue
-                    if ($wingetCheck) {
-                        $script:codexTerminalBox.AppendText(">> Running: winget install OpenJS.NodeJS.LTS`r`n")
-                        [System.Windows.Forms.Application]::DoEvents()
-
-                        $installProc = Start-Process -FilePath "winget" -ArgumentList "install OpenJS.NodeJS.LTS --accept-source-agreements --accept-package-agreements" -Wait -PassThru -WindowStyle Normal
-
-                        if ($installProc.ExitCode -eq 0) {
-                            $script:codexTerminalBox.AppendText("[OK] Node.js installed successfully!`r`n")
-                            $script:codexTerminalBox.AppendText("`r`n>> Please click 'Setup Codex Auth' again to continue.`r`n")
-                            $script:lblCodexStatus.Text = 'Node.js installed! Click "Setup Codex Auth" again to continue.'
-                            $script:lblCodexStatus.ForeColor = $script:MatrixGreen
-
-                            # Refresh PATH for this session
-                            $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
-                        } else {
-                            $script:codexTerminalBox.AppendText("[WARNING] winget install may have failed. Try clicking Setup again.`r`n")
-                            $script:lblCodexStatus.Text = 'Installation may have completed. Click "Setup Codex Auth" to retry.'
-                        }
-                    } else {
-                        $script:codexTerminalBox.AppendText("[ERROR] winget not available`r`n")
-                        $script:codexTerminalBox.AppendText(">> Opening Node.js download page...`r`n")
-                        Start-Process "https://nodejs.org/"
-                        $script:lblCodexStatus.Text = 'Install Node.js from the browser, then click "Setup Codex Auth" again.'
-                    }
-                } catch {
-                    $script:codexTerminalBox.AppendText("[ERROR] Auto-install failed: $($_.Exception.Message)`r`n")
-                    $script:lblCodexStatus.Text = 'Auto-install failed. Click "Setup Codex Auth" to retry after manual install.'
-                }
-            } else {
-                # User chose manual install - open browser
-                $script:codexTerminalBox.AppendText("`r`n>> Opening Node.js download page...`r`n")
-                Start-Process "https://nodejs.org/"
-                $script:codexTerminalBox.AppendText(">> After installing, click 'Setup Codex Auth' again.`r`n")
-                $script:lblCodexStatus.Text = 'Install Node.js from the browser, then click "Setup Codex Auth" again.'
-            }
-            return
-        }
-    }
-
-    $script:codexTerminalBox.AppendText("[OK] Node.js/npm validated (version: $($npmCheck.Version))`r`n")
-    Write-Host "[OK] npm validated at: $($npmCheck.Path)" -ForegroundColor Green
-
-    # Install Codex globally
-    $script:lblCodexStatus.Text = 'Installing Codex CLI on Windows (temporary)...'
-    $script:codexTerminalBox.AppendText("`r`n>> Installing @openai/codex globally...`r`n")
-    [System.Windows.Forms.Application]::DoEvents()
-
-    try {
-        $installResult = & npm install -g @openai/codex 2>&1
-        $script:codexTerminalBox.AppendText("$installResult`r`n")
-        [System.Windows.Forms.Application]::DoEvents()
-    } catch {
-        $script:codexTerminalBox.AppendText("[ERROR] Failed to install Codex: $($_.Exception.Message)`r`n")
-        $script:lblCodexStatus.Text = 'Failed to install Codex. Check console for details.'
-        return
-    }
-
-    # Find codex executable
-    $codexPath = Get-Command codex -ErrorAction SilentlyContinue
-    if (-not $codexPath) {
-        # Try common npm global paths
-        $npmPrefix = & npm config get prefix 2>$null
-        $possibleCodex = Join-Path $npmPrefix "codex.cmd"
-        if (Test-Path $possibleCodex) {
-            $codexPath = @{ Source = $possibleCodex }
-        } else {
-            $script:codexTerminalBox.AppendText("[ERROR] Codex installed but not found in PATH`r`n")
-            $script:lblCodexStatus.Text = 'Codex not found. Try restarting setup.'
-            return
-        }
-    }
-
-    $script:codexTerminalBox.AppendText("[OK] Codex CLI installed`r`n")
-
-    # Show instructions before launching auth (skip in DEV MODE for faster testing)
-    if (-not $script:IsDevMode) {
-        $authInstructions = [System.Windows.Forms.MessageBox]::Show(
-            "Codex is now ready for authentication.`n`n" +
-            "What will happen next:`n" +
-            "1. A command window will open running 'codex auth login'`n" +
-            "2. Your browser will open to the OpenAI login page`n" +
-            "3. Sign in with your OpenAI account (ChatGPT Plus/Pro)`n" +
-            "4. After signing in, return to this wizard`n`n" +
-            "The OAuth server will run on your Windows machine,`n" +
-            "so the localhost callback will work correctly.`n`n" +
-            "Click OK to begin authentication.",
-            "Codex Authentication Instructions",
-            [System.Windows.Forms.MessageBoxButtons]::OK,
-            [System.Windows.Forms.MessageBoxIcon]::Information
-        )
-    } else {
-        Write-Host "[DEV MODE] Skipping Codex auth instructions popup" -ForegroundColor Magenta
-    }
-
-    # Launch Codex for authentication
-    $script:lblCodexStatus.Text = 'Opening browser for authentication... Please sign in.'
-    $script:codexTerminalBox.AppendText("`r`n>> Launching Codex authentication...`r`n")
-    $script:codexTerminalBox.AppendText(">> Your browser will open - please sign in with your OpenAI account`r`n")
-    $script:codexTerminalBox.AppendText(">> A local server will start on Windows to handle the OAuth callback`r`n")
-    $script:codexTerminalBox.AppendText(">> Waiting for authentication to complete...`r`n")
-    $script:codexTerminalBox.AppendText("`r`n>> Running: codex auth login`r`n")
-    [System.Windows.Forms.Application]::DoEvents()
-
-    # Run 'codex auth login' properly through cmd.exe in a new window
-    # This will:
-    # 1. Start a local OAuth server on Windows (listening on localhost:1455)
-    # 2. Open browser to OpenAI OAuth page
-    # 3. Handle the redirect to localhost:1455/auth/callback
-    # 4. Save the token to %USERPROFILE%\.codex\auth.json
-    $codexAuthProcess = Start-Process -FilePath "cmd.exe" -ArgumentList "/k", "codex", "auth", "login" -PassThru -WindowStyle Normal
-
-    $script:codexTerminalBox.AppendText("[INFO] Codex auth window opened - follow instructions in the new window`r`n")
-    $script:codexTerminalBox.AppendText("[INFO] After signing in, the browser will redirect to localhost:1455`r`n")
-    $script:codexTerminalBox.AppendText("[INFO] The auth window will show success message when complete`r`n")
-    $script:codexTerminalBox.AppendText("[INFO] You can close the cmd window after seeing 'Authentication successful'`r`n")
-
-    # Wait for auth.json to appear (poll every 3 seconds, max 5 minutes for user to complete auth)
-    $authFile = Join-Path $env:USERPROFILE ".codex\auth.json"
-    $maxWait = 300
-    $waited = 0
-
-    while ($waited -lt $maxWait) {
-        if (Test-Path $authFile) {
-            $script:codexTerminalBox.AppendText("`r`n[SUCCESS] Authentication completed!`r`n")
-            $script:codexTerminalBox.AppendText("[SUCCESS] Found auth.json at: $authFile`r`n")
-            Write-Host "[SUCCESS] Codex auth.json found" -ForegroundColor Green
-
-            # Auto-close the Codex auth cmd window now that auth is complete
-            if ($codexAuthProcess -and -not $codexAuthProcess.HasExited) {
-                $script:codexTerminalBox.AppendText("[INFO] Closing Codex auth window automatically...`r`n")
-                Write-Host "[INFO] Auto-closing Codex auth window" -ForegroundColor Cyan
-                try {
-                    $codexAuthProcess.CloseMainWindow() | Out-Null
-                    Start-Sleep -Milliseconds 500
-                    if (-not $codexAuthProcess.HasExited) {
-                        $codexAuthProcess.Kill()
-                    }
-                    $script:codexTerminalBox.AppendText("[OK] Auth window closed`r`n")
-                } catch {
-                    Write-Host "[WARNING] Could not auto-close auth window: $($_.Exception.Message)" -ForegroundColor Yellow
-                }
-            }
-            break
-        }
-        # Use smaller sleep increments to keep UI responsive (prevents "Not Responding")
-        for ($i = 0; $i -lt 30; $i++) {
-            Start-Sleep -Milliseconds 100
-            [System.Windows.Forms.Application]::DoEvents()
-        }
-        $waited += 3
-        $remainingTime = $maxWait - $waited
-        $script:lblCodexStatus.Text = "Waiting for authentication... ($waited/$maxWait seconds - $remainingTime remaining)"
-        [System.Windows.Forms.Application]::DoEvents()
-    }
-
-    if (-not (Test-Path $authFile)) {
-        $script:codexTerminalBox.AppendText("`r`n[TIMEOUT] Authentication not completed within 5 minutes`r`n")
-        $script:codexTerminalBox.AppendText("[INFO] You can try again by clicking 'Setup Codex Auth' or click 'Skip'`r`n")
-        $script:lblCodexStatus.Text = 'Authentication timed out. Try again or click Skip to continue.'
-        return
-    }
-
-    # Copy auth to container
-    $script:lblCodexStatus.Text = 'Copying authentication to container...'
-    $script:codexTerminalBox.AppendText("`r`n>> Copying auth to Docker container...`r`n")
-    [System.Windows.Forms.Application]::DoEvents()
-
-    # Get username - try from state first, then from .env file
-    $containerUser = $state.UserName
-    if (-not $containerUser) {
-        # Try to read from .env file
-        $envFile = Join-Path $PSScriptRoot ".env"
-        if (Test-Path $envFile) {
-            $envContent = Get-Content $envFile
-            foreach ($line in $envContent) {
-                if ($line -match '^USER_NAME=(.+)$') {
-                    $containerUser = $matches[1]
-                    break
-                }
-            }
-        }
-    }
-
-    if (-not $containerUser) {
-        $containerUser = "user"  # Fallback default
-        $script:codexTerminalBox.AppendText("[WARNING] Could not determine container username, using 'user'`r`n")
-    }
-
-    $script:codexTerminalBox.AppendText(">> Target user: $containerUser`r`n")
-    $script:codexTerminalBox.AppendText(">> Source file: $authFile`r`n")
-    Write-Host "[DEBUG] Copying auth for user: $containerUser" -ForegroundColor Cyan
-
-    try {
-        # Ensure .codex directory exists
-        $script:codexTerminalBox.AppendText(">> Creating .codex directory...`r`n")
-        $mkdirResult = & docker exec ai-cli mkdir -p "/home/$containerUser/.codex" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            $script:codexTerminalBox.AppendText("[ERROR] mkdir failed: $mkdirResult`r`n")
-        }
-
-        & docker exec ai-cli chown "${containerUser}:${containerUser}" "/home/$containerUser/.codex" 2>&1 | Out-Null
-
-        # Copy auth file
-        $script:codexTerminalBox.AppendText(">> Copying auth.json...`r`n")
-        $copyResult = & docker cp $authFile "ai-cli:/home/$containerUser/.codex/auth.json" 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            $script:codexTerminalBox.AppendText("[ERROR] docker cp failed: $copyResult`r`n")
-            throw "Docker cp failed"
-        }
-
-        & docker exec ai-cli chown "${containerUser}:${containerUser}" "/home/$containerUser/.codex/auth.json" 2>&1 | Out-Null
-        & docker exec ai-cli chmod 600 "/home/$containerUser/.codex/auth.json" 2>&1 | Out-Null
-
-        # Verify the file was copied
-        $verifyResult = & docker exec ai-cli test -f "/home/$containerUser/.codex/auth.json" 2>&1
-        if ($LASTEXITCODE -eq 0) {
-            $script:codexTerminalBox.AppendText("[OK] Auth copied and verified in container`r`n")
-            Write-Host "[SUCCESS] Auth copied to container" -ForegroundColor Green
-        } else {
-            $script:codexTerminalBox.AppendText("[ERROR] Auth file not found in container after copy!`r`n")
-            throw "Verification failed"
-        }
-    } catch {
-        $script:codexTerminalBox.AppendText("[ERROR] Could not copy auth: $($_.Exception.Message)`r`n")
-        Write-Host "[ERROR] Auth copy failed: $($_.Exception.Message)" -ForegroundColor Red
-    }
-
-    # Ask user about cleanup (skip popup in DEV MODE but still auto-remove for security)
-    if (-not $script:IsDevMode) {
-        $cleanupResult = [System.Windows.Forms.MessageBox]::Show(
-            "Codex authentication was successful!`n`nWould you like to REMOVE Codex from Windows?`n`n" +
-            "This will:`n" +
-            "- Uninstall @openai/codex from npm`n" +
-            "- Delete the .codex folder (your auth is already copied to Docker)`n`n" +
-            "WARNING: If you use Codex outside of this Docker setup, click 'No'.`n`n" +
-            "- Click 'Yes' to remove (recommended if only using Docker)`n" +
-            "- Click 'No' to keep Codex installed on Windows",
-            "Remove Codex from Windows?",
-            [System.Windows.Forms.MessageBoxButtons]::YesNo,
-            [System.Windows.Forms.MessageBoxIcon]::Warning
-        )
-    } else {
-        Write-Host "[DEV MODE] Skipping Codex cleanup popup - auto-removing for security" -ForegroundColor Magenta
-        $cleanupResult = [System.Windows.Forms.DialogResult]::Yes  # Auto-remove in DEV MODE
-    }
-
-    if ($cleanupResult -eq [System.Windows.Forms.DialogResult]::Yes) {
-        $script:lblCodexStatus.Text = 'Removing Codex from Windows...'
-        $script:codexTerminalBox.AppendText("`r`n>> Uninstalling Codex from Windows...`r`n")
-        [System.Windows.Forms.Application]::DoEvents()
-
-        try {
-            # Uninstall Codex from npm
-            $script:codexTerminalBox.AppendText(">> Running: npm uninstall -g @openai/codex`r`n")
-            $uninstallResult = & npm uninstall -g @openai/codex 2>&1
-            $script:codexTerminalBox.AppendText("$uninstallResult`r`n")
-
-            # Remove .codex folder from Windows (contains auth.json we already copied)
-            $codexFolder = Join-Path $env:USERPROFILE ".codex"
-            if (Test-Path $codexFolder) {
-                # Check for running Codex processes before deletion
-                $codexProcesses = Get-Process -Name "*codex*" -ErrorAction SilentlyContinue
-                if ($codexProcesses) {
-                    $script:codexTerminalBox.AppendText("[WARNING] Codex processes are running - skipping .codex folder removal`r`n")
-                    $script:codexTerminalBox.AppendText("[INFO] Close Codex and manually delete: $codexFolder`r`n")
-                    Write-Host "[WARNING] Codex processes running, skipping folder removal" -ForegroundColor Yellow
-                } else {
-                    $script:codexTerminalBox.AppendText(">> Removing .codex folder from Windows...`r`n")
-                    Remove-Item -Path $codexFolder -Recurse -Force -ErrorAction SilentlyContinue
-                    $script:codexTerminalBox.AppendText("[OK] Removed .codex folder from Windows`r`n")
-                }
-            }
-
-            # Verify removal
-            $codexCheck = Get-Command codex -ErrorAction SilentlyContinue
-            if ($codexCheck) {
-                $script:codexTerminalBox.AppendText("[WARNING] Codex command still found in PATH`r`n")
-                $script:codexTerminalBox.AppendText("[INFO] You may need to restart your terminal or system`r`n")
-                Write-Host "[WARNING] Codex may still be cached in PATH" -ForegroundColor Yellow
-            } else {
-                $script:codexTerminalBox.AppendText("[VERIFIED] Codex successfully removed from Windows`r`n")
-                Write-Host "[SUCCESS] Codex verified removed from Windows" -ForegroundColor Green
-            }
-
-            $script:codexTerminalBox.AppendText("[OK] Codex cleanup complete`r`n")
-        } catch {
-            $script:codexTerminalBox.AppendText("[WARNING] Could not fully uninstall: $($_.Exception.Message)`r`n")
-        }
-    } else {
-        $script:codexTerminalBox.AppendText("`r`n>> Keeping Codex installed on Windows`r`n")
-        Write-Host "[INFO] User chose to keep Codex on Windows" -ForegroundColor Yellow
-    }
-
-    $script:codexSetupDone = $true
-    $script:lblCodexStatus.Text = 'Codex authentication complete! Advancing to finish...'
-    $script:lblCodexStatus.ForeColor = $script:MatrixGreen
-    $script:codexTerminalBox.AppendText("`r`n>> CODEX SETUP COMPLETE!`r`n")
-    $script:codexTerminalBox.AppendText(">> You can now use 'codex' in your Docker container with your subscription.`r`n")
-    Write-Host "[SUCCESS] Codex setup complete" -ForegroundColor Green
-
-    # Auto-advance to the Done page after successful setup
-    Start-Sleep -Milliseconds 1500  # Brief pause so user can see success message
-    $script:current++
-    Show-Page $script:current
-})
-
+$p6.Controls.Add((New-Label 'AI CLI Tools Environment successfully initialized!' 20 95 880 24 10 $true $true))
+$p6.Controls.Add((New-Label '' 20 120 880 24 10 $false $true))
+$p6.Controls.Add((New-Label 'INSTALLED TOOLS: Claude Code, GitHub CLI, Gemini CLI, OpenAI SDK, Codex CLI' 20 140 880 24 10 $true $true))
+$p6.Controls.Add((New-Label '' 20 165 880 24 10 $false $true))
+$p6.Controls.Add((New-Label 'GETTING STARTED - Quick Setup:' 20 190 880 24 10 $true $true))
+$p6.Controls.Add((New-Label '' 20 210 880 24 10 $false $true))
+$p6.Controls.Add((New-Label '1. Click "LAUNCH AI WORKSPACE" on the main menu' 20 235 880 24 9 $false $true))
+$p6.Controls.Add((New-Label '' 20 255 880 24 10 $false $true))
+$p6.Controls.Add((New-Label '2. In the terminal, run: configure-tools' 20 280 880 24 9 $false $true))
+$p6.Controls.Add((New-Label '   - This wizard will help you sign into all AI services' 20 300 880 24 9 $false $true))
+$p6.Controls.Add((New-Label '   - You can skip tools you don''t have API keys for' 20 320 880 24 9 $false $true))
+$p6.Controls.Add((New-Label '' 20 340 880 24 10 $false $true))
+$p6.Controls.Add((New-Label 'AVAILABLE COMMANDS:' 20 365 880 24 10 $true $true))
+$p6.Controls.Add((New-Label '   claude, gh, gemini, codex' 20 385 880 24 9 $false $true))
+$p6.Controls.Add((New-Label '' 20 405 880 24 10 $false $true))
+$p6.Controls.Add((New-Label 'MANAGEMENT COMMANDS:' 20 430 880 24 10 $true $true))
+$p6.Controls.Add((New-Label '   update-tools (check for updates), config-status (view config)' 20 450 880 24 9 $false $true))
 $pages += $p6
-
-# Page 7: Done
-$p7 = New-PanelPage
-$p7.Controls.Add((New-Label -text '==================================================================================' -x 20 -y 10 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
-$p7.Controls.Add((New-Label -text 'SETUP COMPLETE - YOUR AI ENVIRONMENT IS READY!' -x 20 -y 30 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
-$p7.Controls.Add((New-Label -text '==================================================================================' -x 20 -y 50 -w 880 -h 20 -fontSize 10 -bold $true -center $true))
-$p7.Controls.Add((New-Label '' 20 75 880 24 10 $false $true))
-$p7.Controls.Add((New-Label 'AI CLI Tools Environment successfully initialized!' 20 95 880 24 10 $true $true))
-$p7.Controls.Add((New-Label '' 20 120 880 24 10 $false $true))
-$p7.Controls.Add((New-Label 'INSTALLED TOOLS: Claude Code, GitHub CLI, Gemini CLI, OpenAI SDK, Codex CLI' 20 140 880 24 10 $true $true))
-$p7.Controls.Add((New-Label '' 20 165 880 24 10 $false $true))
-$p7.Controls.Add((New-Label 'GETTING STARTED - Quick Setup:' 20 190 880 24 10 $true $true))
-$p7.Controls.Add((New-Label '' 20 210 880 24 10 $false $true))
-$p7.Controls.Add((New-Label '1. Click "LAUNCH AI WORKSPACE" on the main menu' 20 235 880 24 9 $false $true))
-$p7.Controls.Add((New-Label '' 20 255 880 24 10 $false $true))
-$p7.Controls.Add((New-Label '2. In the terminal, run: configure-tools' 20 280 880 24 9 $false $true))
-$p7.Controls.Add((New-Label '   - This wizard will help you sign into all AI services' 20 300 880 24 9 $false $true))
-$p7.Controls.Add((New-Label '   - You can skip tools you don''t have API keys for' 20 320 880 24 9 $false $true))
-$p7.Controls.Add((New-Label '' 20 340 880 24 10 $false $true))
-$p7.Controls.Add((New-Label 'AVAILABLE COMMANDS:' 20 365 880 24 10 $true $true))
-$p7.Controls.Add((New-Label '   claude, gh, gemini, codex' 20 385 880 24 9 $false $true))
-$p7.Controls.Add((New-Label '' 20 405 880 24 10 $false $true))
-$p7.Controls.Add((New-Label 'MANAGEMENT COMMANDS:' 20 430 880 24 10 $true $true))
-$p7.Controls.Add((New-Label '   update-tools (check for updates), config-status (view config)' 20 450 880 24 9 $false $true))
-$pages += $p7
 
 # ---------- page plumbing ----------
 $form.Controls.Add($pages[0])
@@ -1326,14 +897,8 @@ function Show-Page([int]$i) {
     $btnBack.Enabled = ($i -gt 0)
     if ($i -eq $pages.Count-1) { $btnNext.Text = 'Finish' } else { $btnNext.Text = 'Next' }
 
-    # Hide progress bar on Codex auth page (page 6) to avoid overlap with Setup/Skip buttons
-    if ($i -eq 6) {
-        $progress.Visible = $false
-        $status.Visible = $false
-    } else {
-        $progress.Visible = $true
-        $status.Visible = $true
-    }
+    $progress.Visible = $true
+    $status.Visible = $true
 }
 $btnCancel.Add_Click({
     Write-Host '[WARNING] User requested cancellation' -ForegroundColor Yellow
@@ -1590,10 +1155,10 @@ $btnNext.Add_Click({
                 [System.Windows.Forms.Application]::DoEvents()
                 Write-Host "[DEV MODE] CLI tools simulation complete" -ForegroundColor Magenta
 
-                # Go to Codex auth page in DEV MODE for testing
-                Write-Host "[DEV MODE] Proceeding to Codex auth page for testing" -ForegroundColor Magenta
-                $status.Text = '[DEV MODE] Codex auth page (testing)'
-                $script:current++  # Go to page 6 (Codex auth)
+                # Go to Done page in DEV MODE
+                Write-Host "[DEV MODE] Proceeding to Done page" -ForegroundColor Magenta
+                $status.Text = '[DEV MODE] Done page'
+                $script:current++  # Go to page 6 (Done)
                 Show-Page $script:current
                 return
             }
@@ -1904,15 +1469,6 @@ $btnNext.Add_Click({
             $status.Text = 'Installation is automatic - please wait...'
         }
         6 {
-            # Codex auth page - only advance if setup was done or skipped
-            if ($script:codexSetupDone) {
-                $script:current++; Show-Page $script:current
-            } else {
-                # User clicked Next without setting up or skipping - remind them
-                Show-Error "Please click 'Setup Codex Auth' to configure Codex, or 'Skip' to continue without it."
-            }
-        }
-        7 {
             Write-Host "[INFO] User clicked Finish - closing wizard" -ForegroundColor Green
             $form.Close()
             $form.DialogResult = [System.Windows.Forms.DialogResult]::OK


### PR DESCRIPTION
## Summary
- Remove Page 6 (Codex Subscription Auth) from setup wizard
- Remove Codex auth auto-sync from launch script
- Add retry logic with cache clearing for npm/pip package installations
- Bump version to 1.1.1

OpenAI fixed native Docker OAuth support (openai/codex#2798), so users can now authenticate directly in container with `codex auth login`.

## Test plan
- [x] Rebuilt container - Codex CLI installed successfully with retry logic
- [x] Setup wizard pages 0-6 navigate correctly
- [x] Version displays as 1.1.1 in UI footer
- [ ] CI passes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)