### PR TITLE
fix: Clarify update-tools scope, add dynamic package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-01-20
+
+### Changed
+- Renamed `update-tools` to `update-container-tools` for clarity (old alias still works)
+- Renamed `check-updates` to `check-container-updates` for clarity (old alias still works)
+- Update commands now dynamically update ALL installed npm/pip packages instead of hardcoded list
+- Login banner now shows NOTE clarifying that commands update container tools only
+
+### Added
+- Clear messaging in update script explaining scope (container tools vs launcher app)
+- Help text clarifies that launcher app updates must be downloaded from GitHub
+
+### Fixed
+- Confusion between container tool updates and launcher app updates
+
 ## [1.1.1] - 2025-01-20
 
 ### Changed
@@ -90,12 +105,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Description |
 |---------|------|-------------|
+| 1.1.2 | 2025-01-20 | Clarify update-tools scope, dynamic package updates |
 | 1.1.1 | 2025-01-20 | Remove Codex OAuth workaround, add install retry logic |
 | 1.1.0 | 2025-01-17 | Vibe Kanban integration |
 | 1.0.1 | 2025-12-11 | Add version display and Report Issue link |
 | 1.0.0 | 2025-12-11 | Initial production release |
 
-[Unreleased]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/Cainmani/ai-docker-cli-setup/compare/v1.0.0...v1.0.1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -72,8 +72,11 @@ alias grep='grep --color=auto'
 export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
 
 # CLI tools aliases
-alias update-tools='/usr/local/bin/auto_update.sh'
-alias check-updates='/usr/local/bin/auto_update.sh --check'
+# Note: These commands update container CLI tools only, not the Windows launcher app
+alias update-container-tools='/usr/local/bin/auto_update.sh'
+alias update-tools='/usr/local/bin/auto_update.sh'  # Legacy alias for compatibility
+alias check-container-updates='/usr/local/bin/auto_update.sh --check'
+alias check-updates='/usr/local/bin/auto_update.sh --check'  # Legacy alias for compatibility
 alias configure-tools='/usr/local/bin/configure_tools.sh'
 alias config-status='/usr/local/bin/configure_tools.sh --status'
 
@@ -92,10 +95,13 @@ if [ -f "$HOME/.cli_tools_installed" ]; then
   echo "|   * python3      - OpenAI Python SDK (import openai)        |"
   echo "|                                                             |"
   echo "| Management Commands:                                        |"
-  echo "|   * configure-tools  - Set up API keys and authentication   |"
-  echo "|   * config-status    - Check configuration status           |"
-  echo "|   * update-tools     - Update all CLI tools                 |"
-  echo "|   * check-updates    - Check for available updates          |"
+  echo "|   * configure-tools        - Set up API keys/authentication |"
+  echo "|   * config-status          - Check configuration status     |"
+  echo "|   * update-container-tools - Update CLI tools in container  |"
+  echo "|   * check-container-updates - Check for tool updates        |"
+  echo "+--------------------------------------------------------------+"
+  echo "| NOTE: These commands update container tools only.           |"
+  echo "|       To update the launcher app, download from GitHub.     |"
   echo "+==============================================================+"
   echo ""
   echo "First time? Run 'configure-tools' to set up your API keys!"

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -61,7 +61,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.1.1"
+$script:AppVersion = "1.1.2"
 $script:GitHubRepo = "Cainmani/ai-docker-cli-setup"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -38,7 +38,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.1.1"
+$script:AppVersion = "1.1.2"
 $script:GitHubRepo = "Cainmani/ai-docker-cli-setup"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 


### PR DESCRIPTION
## Summary
- Rename `update-tools` to `update-container-tools` for clarity (old alias still works for compatibility)
- Rename `check-updates` to `check-container-updates` for clarity (old alias still works)
- Add clear messaging that commands update container tools only, not the launcher app
- Make npm/pip updates dynamic (updates ALL installed packages instead of hardcoded list)
- Update login banner with NOTE about launcher app updates
- Bump version to 1.1.2

## Problem
Users were confused when running `update-tools` after seeing "new version available" for the launcher app. They expected `update-tools` to update everything, but it only updates CLI tools inside the container.

## Solution
- Clearer command names (`update-container-tools`)
- Explicit messaging during updates showing what is/isn't being updated
- Login banner now includes a NOTE explaining the scope
- Help text clarifies that launcher updates must be downloaded from GitHub

## Test plan
- [x] Rebuilt container with new entrypoint.sh
- [x] Verified login banner shows new commands and NOTE
- [x] Verified `update-container-tools` shows clear scope messaging
- [x] Verified dynamic npm updates work (598 packages updated in test)
- [x] Verified tab completion shows new command names
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)