### PR TITLE
fix: batch audit fixes — sanitization, bugs, metadata, CI linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,40 @@ jobs:
 
           Write-Host "Validation complete"
 
+      - name: Lint shell scripts (shellcheck)
+        shell: bash
+        continue-on-error: true
+        run: |
+          if ! command -v shellcheck &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          fi
+          echo "shellcheck version: $(shellcheck --version | grep '^version:' || true)"
+          echo ""
+          failed=0
+          for script in docker/*.sh docker/lib/*.sh; do
+            [ -f "$script" ] || continue
+            echo "=== Checking $script ==="
+            if shellcheck -S warning "$script"; then
+              echo "  OK"
+            else
+              failed=$((failed + 1))
+            fi
+            echo ""
+          done
+          echo "shellcheck: $failed script(s) with warnings"
+
+      - name: Lint Dockerfile (hadolint)
+        shell: bash
+        continue-on-error: true
+        run: |
+          if ! command -v hadolint &>/dev/null; then
+            sudo curl -sL "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64" -o /usr/local/bin/hadolint
+            sudo chmod +x /usr/local/bin/hadolint
+          fi
+          echo "hadolint version: $(hadolint --version)"
+          echo ""
+          hadolint docker/Dockerfile
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/docker/auto_update.sh
+++ b/docker/auto_update.sh
@@ -44,12 +44,13 @@ UPDATE_INTERVAL_DAYS=${UPDATE_INTERVAL_DAYS:-7}  # Default: check weekly
 # Uses the shared logging library if available, otherwise falls back to simple logging
 update_log() {
     local msg="$1"
+    # Strip ANSI color codes (literal \033[...m sequences) for clean log output
+    local clean_msg
+    clean_msg=$(printf '%s' "$msg" | sed 's/\\033\[[0-9;]*m//g')
     if [ "$LOGGING_LIBRARY_AVAILABLE" = "1" ]; then
-        # Use the shared logging library
-        log_info "UPDATE" "$msg" "$LOG_FILE"
+        log_info "UPDATE" "$clean_msg" "$LOG_FILE"
     else
-        # Fallback to simple logging (with basic sanitization)
-        local sanitized="$msg"
+        local sanitized="$clean_msg"
         local user_name
         user_name="$(whoami 2>/dev/null || echo '')"
         if [ -n "$user_name" ]; then
@@ -57,8 +58,9 @@ update_log() {
         fi
         sanitized="$(echo "$sanitized" | sed -E 's/sk-(proj-|ant-)?[a-zA-Z0-9_-]{20,}/<REDACTED_API_KEY>/g; s/gh[pousr]_[a-zA-Z0-9]{36,}/<REDACTED_TOKEN>/g')"
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] $sanitized" >> "$LOG_FILE"
-        echo -e "$msg"
     fi
+    # Always echo with colors to terminal
+    echo -e "$msg"
 }
 
 # Function to check if update is needed

--- a/docker/configure_tools.sh
+++ b/docker/configure_tools.sh
@@ -255,12 +255,13 @@ configure_codex() {
     local config_file="${HOME}/.codex/config.toml"
     if [ ! -f "$config_file" ]; then
         print_status "Creating default Codex config.toml..."
-        cat > "$config_file" << 'TOML'
+            local codex_model="${CODEX_MODEL:-gpt-5.2-codex}"
+        cat > "$config_file" << TOML
 # Codex CLI Configuration
 # See: https://developers.openai.com/codex/config-reference/
 
-# Model settings
-model = "gpt-5.2-codex"
+# Model settings (override with CODEX_MODEL env var)
+model = "$codex_model"
 model_provider = "openai"
 
 # Safety settings

--- a/docker/lib/logging.sh
+++ b/docker/lib/logging.sh
@@ -55,14 +55,13 @@ sanitize_message() {
     msg=$(echo "$msg" | sed -E "s|C:\\\\Users\\\\[^\\\\]+\\\\|C:\\\\Users\\\\<USER>\\\\|g")
     msg=$(echo "$msg" | sed -E "s|C:/Users/[^/]+/|C:/Users/<USER>/|g")
 
-    # Sanitize API keys (OpenAI sk-... and sk-proj-... patterns)
+    # Sanitize API keys — most-specific prefixes first to avoid partial matches
+    msg=$(echo "$msg" | sed -E "s|sk-ant-[a-zA-Z0-9_-]{20,}|<REDACTED_API_KEY>|g")
     msg=$(echo "$msg" | sed -E "s|sk-proj-[a-zA-Z0-9_-]{20,}|<REDACTED_API_KEY>|g")
     msg=$(echo "$msg" | sed -E "s|sk-[a-zA-Z0-9]{20,}|<REDACTED_API_KEY>|g")
 
-    # Sanitize Anthropic API keys
-    msg=$(echo "$msg" | sed -E "s|sk-ant-[a-zA-Z0-9_-]{20,}|<REDACTED_API_KEY>|g")
-
-    # Sanitize GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+    # Sanitize GitHub tokens (classic ghp_/gho_/ghu_/ghs_/ghr_ and fine-grained github_pat_)
+    msg=$(echo "$msg" | sed -E "s|github_pat_[a-zA-Z0-9]{22,}|<REDACTED_TOKEN>|g")
     msg=$(echo "$msg" | sed -E "s|gh[pousr]_[a-zA-Z0-9]{36,}|<REDACTED_TOKEN>|g")
 
     # Sanitize generic tokens/secrets (token=xxx, TOKEN: xxx, secret=xxx)

--- a/scripts/build/build_complete_exe.ps1
+++ b/scripts/build/build_complete_exe.ps1
@@ -158,9 +158,9 @@ try {
         -outputFile $exePath `
         -title "AI Docker Manager" `
         -description "Complete AI CLI Docker Setup System" `
-        -company "Your Company" `
+        -company "AI Docker Sandbox" `
         -product "AI Docker CLI Setup" `
-        -version "2.0.0.0" `
+        -version "1.2.2.0" `
         -noConsole
 
     if (Test-Path $exePath) {

--- a/scripts/log_utils.ps1
+++ b/scripts/log_utils.ps1
@@ -39,12 +39,13 @@ function Sanitize-LogMessage {
         $Message = $Message -replace "\b$([regex]::Escape($script:ContainerUsername))\b", "<USER>"
     }
 
-    # Sanitize API keys (OpenAI sk-proj-... and sk-... patterns)
+    # Sanitize API keys — most-specific prefixes first to avoid partial matches
+    $Message = $Message -replace "sk-ant-[a-zA-Z0-9_-]{20,}", "<REDACTED_API_KEY>"
     $Message = $Message -replace "sk-proj-[a-zA-Z0-9_-]{20,}", "<REDACTED_API_KEY>"
     $Message = $Message -replace "sk-[a-zA-Z0-9]{20,}", "<REDACTED_API_KEY>"
-    $Message = $Message -replace "sk-ant-[a-zA-Z0-9_-]{20,}", "<REDACTED_API_KEY>"
 
-    # Sanitize GitHub tokens
+    # Sanitize GitHub tokens (classic and fine-grained github_pat_)
+    $Message = $Message -replace "github_pat_[a-zA-Z0-9]{22,}", "<REDACTED_TOKEN>"
     $Message = $Message -replace "gh[pousr]_[a-zA-Z0-9]{36,}", "<REDACTED_TOKEN>"
 
     # Sanitize generic tokens/secrets/passwords

--- a/scripts/setup_wizard.ps1
+++ b/scripts/setup_wizard.ps1
@@ -1139,7 +1139,7 @@ $btnCancel.Add_Click({
             $script:runningProcess.WaitForExit(5000)
             Write-Host '[INFO] Process terminated' -ForegroundColor Green
         } catch {
-            Write-Host '[WARNING] Could not kill process: $($_.Exception.Message)' -ForegroundColor Yellow
+            Write-Host "[WARNING] Could not kill process: $($_.Exception.Message)" -ForegroundColor Yellow
         }
     }
 

--- a/tests/LogUtils.Tests.ps1
+++ b/tests/LogUtils.Tests.ps1
@@ -44,6 +44,12 @@ Describe 'Sanitize-LogMessage' {
         Sanitize-LogMessage -Message $msg | Should -Be 'found <REDACTED_TOKEN> here'
     }
 
+    It 'Redacts fine-grained GitHub tokens (github_pat_)' {
+        $token = 'github_pat_' + ('C' * 22)
+        $msg = "pat: $token"
+        Sanitize-LogMessage -Message $msg | Should -Be 'pat: <REDACTED_TOKEN>'
+    }
+
     It 'Redacts password values' {
         Sanitize-LogMessage -Message 'Password=mysecret123' | Should -Be 'Password=<REDACTED>'
         Sanitize-LogMessage -Message 'password: hunter2' | Should -Be 'password=<REDACTED>'

--- a/tests/run_tests.ps1
+++ b/tests/run_tests.ps1
@@ -424,6 +424,7 @@ Test-Assertion "CLI_TOOLS_GUIDE.md documents Vibe Kanban" {
     }
 } "Vibe Kanban not documented in CLI guide"
 
+$userManualFile = Join-Path $projectRoot 'docs\USER_MANUAL.md'
 Test-Assertion "USER_MANUAL.md documents Vibe Kanban" {
     if (Test-Path $userManualFile) {
         $content = Get-Content $userManualFile -Raw

--- a/tests/test_bash_fixes.sh
+++ b/tests/test_bash_fixes.sh
@@ -170,6 +170,40 @@ else
     fail "New-SecurePasswordFile missing from setup_utils.ps1"
 fi
 
+# Phase 6: Sanitization pattern order and CI linting
+echo ""
+echo "--- Phase 6: Sanitization + batch fixes ---"
+
+# SEC-020: sk-ant- must appear before generic sk- in logging.sh
+ant_line=$(grep -n 'sk-ant-' docker/lib/logging.sh | head -1 | cut -d: -f1)
+generic_line=$(grep -n 'sk-\[a-zA-Z0-9\]' docker/lib/logging.sh | head -1 | cut -d: -f1)
+if [ -n "$ant_line" ] && [ -n "$generic_line" ] && [ "$ant_line" -lt "$generic_line" ]; then
+    pass "logging.sh: sk-ant- before generic sk- (SEC-020)"
+else
+    fail "logging.sh: sk-ant- must come before generic sk-"
+fi
+
+# SEC-019: github_pat_ pattern exists in logging.sh
+if grep -q 'github_pat_' docker/lib/logging.sh; then
+    pass "logging.sh has github_pat_ pattern (SEC-019)"
+else
+    fail "logging.sh missing github_pat_ pattern"
+fi
+
+# SEC-019: github_pat_ pattern exists in log_utils.ps1
+if grep -q 'github_pat_' scripts/log_utils.ps1; then
+    pass "log_utils.ps1 has github_pat_ pattern (SEC-019)"
+else
+    fail "log_utils.ps1 missing github_pat_ pattern"
+fi
+
+# CQ-017: update_log strips ANSI codes
+if grep -q 'clean_msg' docker/auto_update.sh; then
+    pass "auto_update.sh strips ANSI codes in update_log (CQ-017)"
+else
+    fail "auto_update.sh does not strip ANSI codes"
+fi
+
 echo ""
 echo "========================================="
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Phase 6 of the audit findings work (issue #40). Batch of 9 audit fixes that don't require Windows testing.

### Security (SEC-019, SEC-020)
- Reorder `sk-` sanitization patterns — most-specific first (`sk-ant-` → `sk-proj-` → `sk-`) in both `logging.sh` and `log_utils.ps1`
- Add `github_pat_` fine-grained token pattern to both sanitizers

### Bug fixes (CQ-012, CQ-014, CQ-017, CQ-026, BP-029)
- **CQ-012**: Fix single-quote string preventing `$($_.Exception.Message)` interpolation in setup_wizard.ps1
- **CQ-014**: Fix `$userManualFile` used before defined in run_tests.ps1
- **CQ-017**: Strip ANSI color codes from log file writes in auto_update.sh
- **CQ-026**: Parameterize hardcoded `gpt-5.2-codex` model string via `CODEX_MODEL` env var
- **BP-029**: Fix build metadata — "Your Company" → "AI Docker Sandbox", version 2.0.0.0 → 1.2.2.0

### CI improvements (BP-020, DEP-019)
- **BP-020**: Add shellcheck linting for `docker/*.sh` (non-blocking, `continue-on-error: true`)
- **DEP-019**: Add hadolint linting for `docker/Dockerfile` (non-blocking)
- Both tools installed on first run, cached on self-hosted runner thereafter

### Tests
- 1 new Pester test (github_pat_ token redaction)
- 4 new bash structural assertions (33 total)

## Test plan
- [ ] All Pester tests pass (including new github_pat_ test)
- [ ] Bash structural tests pass (33 assertions)
- [ ] shellcheck runs (may show warnings — non-blocking)
- [ ] hadolint runs (may show warnings — non-blocking)
- [ ] All docker/*.sh pass `bash -n` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)