### PR TITLE
fix: remaining actionable audit fixes — security, bugs, docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ function getcreds($u) {
 - Use snake_case for variables: `user_name`, `config_path`
 - Use functions for reusable code
 - Always quote variables: `"$variable"`
-- Add `set -e` for fail-fast behavior
+- Add `set -euo pipefail` for strict mode (catches undefined variables and pipe failures)
 
 ### Documentation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,8 +59,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource-setup.sh
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip and install pipx for isolated tool installations
-RUN python3 -m pip install --no-cache-dir --break-system-packages pipx
+# Note: pipx was removed (SEC-005/DEP-017) — installed but never used
 
 
 # Create working directory

--- a/docker/setup_remote_connection.sh
+++ b/docker/setup_remote_connection.sh
@@ -126,11 +126,18 @@ main() {
     if [ -z "$ssh_key" ]; then
         print_warning "No key entered - you can add it later with: add-ssh-key \"your-key\""
     else
-        echo ""
-        if /usr/local/bin/add-ssh-key "$ssh_key" 2>/dev/null || echo "$ssh_key" >> ~/.ssh/authorized_keys 2>/dev/null; then
-            print_success "SSH key added!"
+        # Validate SSH key format
+        if ! echo "$ssh_key" | grep -qE '^(ssh-(rsa|ed25519|dss)|ecdsa-sha2-nistp(256|384|521)) [A-Za-z0-9+/=]+ '; then
+            print_error "Invalid SSH key format"
+            print_info "Key must start with: ssh-rsa, ssh-ed25519, ssh-dss, or ecdsa-sha2-*"
+            print_info "Example: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5... my-phone"
         else
-            print_warning "Could not add key automatically. Try: add-ssh-key \"your-key\""
+            echo ""
+            if /usr/local/bin/add-ssh-key "$ssh_key" 2>/dev/null || echo "$ssh_key" >> ~/.ssh/authorized_keys 2>/dev/null; then
+                print_success "SSH key added!"
+            else
+                print_warning "Could not add key automatically. Try: add-ssh-key \"your-key\""
+            fi
         fi
     fi
 

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -434,7 +434,7 @@ $form.Controls.Add($btnVibeKanban)
 $lblVibeKanbanInfo = New-Object System.Windows.Forms.Label
 $lblVibeKanbanInfo.Left = 70; $lblVibeKanbanInfo.Top = 455
 $lblVibeKanbanInfo.Width = 460; $lblVibeKanbanInfo.Height = 20
-$lblVibeKanbanInfo.Text = "Opens AI agent orchestration web UI (http://localhost:3000)"
+$lblVibeKanbanInfo.Text = "Orchestrate AI agents in parallel via web interface"
 $lblVibeKanbanInfo.ForeColor = $script:MatrixGreen
 $lblVibeKanbanInfo.BackColor = 'Transparent'
 $lblVibeKanbanInfo.Font = New-Object System.Drawing.Font('Consolas', 8)

--- a/scripts/fix_line_endings.ps1
+++ b/scripts/fix_line_endings.ps1
@@ -1,7 +1,7 @@
 # fix_line_endings.ps1 - Convert shell scripts to Unix LF line endings
 
 $scriptPath = $PSScriptRoot
-$files = @('entrypoint.sh', 'setup.sh', 'claude_wrapper.sh', 'install_cli_tools.sh', 'auto_update.sh', 'configure_tools.sh', 'setup_mobile_access.sh', 'add_ssh_key.sh', 'setup_remote_connection.sh', 'tmux.conf', 'docker\lib\logging.sh')
+$files = @('entrypoint.sh', 'install_cli_tools.sh', 'auto_update.sh', 'configure_tools.sh', 'setup_mobile_access.sh', 'add_ssh_key.sh', 'setup_remote_connection.sh', 'tmux.conf', 'docker\lib\logging.sh')
 
 Write-Host "================================================================" -ForegroundColor Green
 Write-Host "         FIXING LINE ENDINGS FOR LINUX SCRIPTS                  " -ForegroundColor Green

--- a/scripts/launch_claude.ps1
+++ b/scripts/launch_claude.ps1
@@ -169,7 +169,7 @@ if (-not $userResult.Valid) {
 Write-AppLog "Final username: [$userName]" "INFO"
 
 # Build the docker exec command - connect as the user and start at /workspace
-$dockerCmd = "`"$dockerPath`" exec -it -u $userName -w /workspace ai-cli bash -l"
+$dockerCmd = "`"$dockerPath`" exec -it -u `"$userName`" -w /workspace ai-cli bash -l"
 Write-AppLog "Docker command: $dockerCmd" "DEBUG"
 
 # Open terminal at /workspace directory

--- a/scripts/launch_vibe_kanban.ps1
+++ b/scripts/launch_vibe_kanban.ps1
@@ -110,7 +110,7 @@ $vibeKanbanRunning = $false
 try {
     # Check if something is actually listening on the vibe-kanban port inside the container
     # Use netstat/ss to check for actual listeners, not pgrep which can match itself
-    $portCheck = & $dockerPath exec -u $userName ai-cli bash -c "netstat -tlnp 2>/dev/null | grep ':$vibeKanbanPort ' || echo 'NOT_LISTENING'" 2>&1
+    $portCheck = & $dockerPath exec -u "$userName" ai-cli bash -c "netstat -tlnp 2>/dev/null | grep ':$vibeKanbanPort ' || echo 'NOT_LISTENING'" 2>&1
     if ($portCheck -and $portCheck -notmatch 'NOT_LISTENING' -and $portCheck -match ':' + $vibeKanbanPort) {
         $vibeKanbanRunning = $true
         Write-AppLog "Vibe Kanban is listening on port $vibeKanbanPort inside container" "INFO"
@@ -130,7 +130,7 @@ if ($vibeKanbanRunning) {
 
 # Check if Vibe Kanban is installed
 Write-AppLog "Checking if Vibe Kanban is installed..." "DEBUG"
-$vibeKanbanCheck = & $dockerPath exec -u $userName ai-cli bash -c "npm list -g vibe-kanban 2>/dev/null | grep vibe-kanban" 2>&1
+$vibeKanbanCheck = & $dockerPath exec -u "$userName" ai-cli bash -c "npm list -g vibe-kanban 2>/dev/null | grep vibe-kanban" 2>&1
 if (-not $vibeKanbanCheck -or $vibeKanbanCheck -notmatch "vibe-kanban") {
     Write-AppLog "Vibe Kanban not installed" "WARN"
     $result = [System.Windows.Forms.MessageBox]::Show(
@@ -146,11 +146,11 @@ if (-not $vibeKanbanCheck -or $vibeKanbanCheck -notmatch "vibe-kanban") {
         Write-AppLog "Installing Vibe Kanban..." "INFO"
         ShowMsg "Installing Vibe Kanban...`n`nThis may take a few minutes. Please wait." 'Information'
 
-        $installResult = & $dockerPath exec -u $userName ai-cli bash -c "npm install -g vibe-kanban@latest" 2>&1
+        $installResult = & $dockerPath exec -u "$userName" ai-cli bash -c "npm install -g vibe-kanban@latest" 2>&1
         Write-AppLog "Install result: $installResult" "DEBUG"
 
         # Verify installation
-        $vibeKanbanCheck = & $dockerPath exec -u $userName ai-cli bash -c "npm list -g vibe-kanban 2>/dev/null | grep vibe-kanban" 2>&1
+        $vibeKanbanCheck = & $dockerPath exec -u "$userName" ai-cli bash -c "npm list -g vibe-kanban 2>/dev/null | grep vibe-kanban" 2>&1
         if (-not $vibeKanbanCheck -or $vibeKanbanCheck -notmatch "vibe-kanban") {
             Write-AppLog "ERROR: Vibe Kanban installation failed" "ERROR"
             ShowMsg "Failed to install Vibe Kanban.`n`nPlease try running the setup wizard again." 'Error'
@@ -169,18 +169,18 @@ Write-AppLog "NOTE: First run may take 1-2 minutes to download required files (~
 
 # First verify vibe-kanban binary location
 # Use bash -l (login shell) to ensure PATH includes npm global bin directory
-$whichResult = & $dockerPath exec -u $userName ai-cli bash -l -c "which vibe-kanban 2>&1" 2>&1
+$whichResult = & $dockerPath exec -u "$userName" ai-cli bash -l -c "which vibe-kanban 2>&1" 2>&1
 Write-AppLog "vibe-kanban location: $whichResult" "DEBUG"
 
 if (-not $whichResult -or $whichResult -match "not found" -or $whichResult -match "no vibe-kanban") {
     Write-AppLog "ERROR: vibe-kanban binary not found in PATH" "ERROR"
 
     # Check npm global bin directory (npm bin -g was removed in npm v9+)
-    $npmBin = & $dockerPath exec -u $userName ai-cli bash -c 'echo $(npm config get prefix)/bin' 2>&1
+    $npmBin = & $dockerPath exec -u "$userName" ai-cli bash -c 'echo $(npm config get prefix)/bin' 2>&1
     Write-AppLog "npm global bin: $npmBin" "DEBUG"
 
     # Check if vibe-kanban exists there
-    $checkNpmBin = & $dockerPath exec -u $userName ai-cli bash -c 'ls -la $(npm config get prefix)/bin/vibe-kanban 2>&1' 2>&1
+    $checkNpmBin = & $dockerPath exec -u "$userName" ai-cli bash -c 'ls -la $(npm config get prefix)/bin/vibe-kanban 2>&1' 2>&1
     Write-AppLog "vibe-kanban in npm bin: $checkNpmBin" "DEBUG"
 
     ShowMsg "Vibe Kanban binary not found in PATH.`n`nThe installation may have failed. Please run First Time Setup again with 'Force Rebuild' checked." 'Error'
@@ -196,7 +196,7 @@ $startCmd = "export PATH=`$HOME/.npm-global/bin:`$HOME/.local/bin:`$PATH && cd /
 Write-AppLog "Start command: $startCmd" "DEBUG"
 
 # Use bash -l (login shell) to source .profile, combined with explicit PATH for redundancy
-$execResult = & $dockerPath exec -u $userName -w /workspace ai-cli bash -l -c $startCmd 2>&1
+$execResult = & $dockerPath exec -u "$userName" -w /workspace ai-cli bash -l -c $startCmd 2>&1
 if ($execResult) {
     Write-AppLog "Exec output: $execResult" "DEBUG"
 }
@@ -205,11 +205,11 @@ if ($execResult) {
 Start-Sleep -Milliseconds 500
 
 # Check if log file was created
-$logExists = & $dockerPath exec -u $userName ai-cli bash -c "test -f /tmp/vibe-kanban.log && echo EXISTS || echo MISSING" 2>&1
+$logExists = & $dockerPath exec -u "$userName" ai-cli bash -c "test -f /tmp/vibe-kanban.log && echo EXISTS || echo MISSING" 2>&1
 Write-AppLog "Log file status: $logExists" "DEBUG"
 
 # Check for immediate errors in log
-$earlyLog = & $dockerPath exec -u $userName ai-cli bash -c "cat /tmp/vibe-kanban.log 2>/dev/null | head -10" 2>&1
+$earlyLog = & $dockerPath exec -u "$userName" ai-cli bash -c "cat /tmp/vibe-kanban.log 2>/dev/null | head -10" 2>&1
 if ($earlyLog) {
     Write-AppLog "Early log output: $earlyLog" "DEBUG"
 }
@@ -240,15 +240,15 @@ if (-not $serverStarted) {
     Write-AppLog "ERROR: Vibe Kanban failed to start within $maxWait seconds" "ERROR"
 
     # Try to get logs for debugging
-    $logs = & $dockerPath exec -u $userName ai-cli bash -c "cat /tmp/vibe-kanban.log 2>/dev/null" 2>&1
+    $logs = & $dockerPath exec -u "$userName" ai-cli bash -c "cat /tmp/vibe-kanban.log 2>/dev/null" 2>&1
     Write-AppLog "Vibe Kanban full log: $logs" "ERROR"
 
     # Check if process is running at all
-    $processCheck = & $dockerPath exec -u $userName ai-cli bash -c "ps aux | grep -v grep | grep vibe-kanban" 2>&1
+    $processCheck = & $dockerPath exec -u "$userName" ai-cli bash -c "ps aux | grep -v grep | grep vibe-kanban" 2>&1
     Write-AppLog "Process check: $processCheck" "DEBUG"
 
     # Check if port is in use by something else
-    $portInUse = & $dockerPath exec -u $userName ai-cli bash -c "netstat -tlnp 2>/dev/null | grep ':$vibeKanbanPort'" 2>&1
+    $portInUse = & $dockerPath exec -u "$userName" ai-cli bash -c "netstat -tlnp 2>/dev/null | grep ':$vibeKanbanPort'" 2>&1
     Write-AppLog "Port $vibeKanbanPort status: $portInUse" "DEBUG"
 
     # Build error message with log excerpt

--- a/scripts/setup_utils.ps1
+++ b/scripts/setup_utils.ps1
@@ -13,7 +13,7 @@ function Fix-LineEndings {
         # Running from project directory - docker files are in ../docker
         Join-Path $scriptPath '..\docker'
     }
-    $files = @('entrypoint.sh', 'setup.sh', 'claude_wrapper.sh')
+    $files = @('entrypoint.sh', 'install_cli_tools.sh', 'auto_update.sh', 'configure_tools.sh', 'setup_mobile_access.sh', 'add_ssh_key.sh', 'setup_remote_connection.sh')
     $fixed = $false
 
     foreach ($file in $files) {

--- a/tests/test_bash_fixes.sh
+++ b/tests/test_bash_fixes.sh
@@ -204,6 +204,45 @@ else
     fail "auto_update.sh does not strip ANSI codes"
 fi
 
+# Phase 7: Remaining actionable fixes
+echo ""
+echo "--- Phase 7: Remaining fixes ---"
+
+# SEC-005/DEP-017: pipx removed from Dockerfile
+if ! grep -q 'install.*pipx' docker/Dockerfile; then
+    pass "Dockerfile does not install pipx (SEC-005/DEP-017)"
+else
+    fail "Dockerfile still installs unused pipx"
+fi
+
+# CQ-024: Fix-LineEndings no stale claude_wrapper.sh reference
+if ! grep -q 'claude_wrapper' scripts/setup_utils.ps1; then
+    pass "setup_utils.ps1 Fix-LineEndings list updated (CQ-024)"
+else
+    fail "setup_utils.ps1 still references deleted claude_wrapper.sh"
+fi
+
+# CQ-029: SSH key validation exists
+if grep -q 'ssh-ed25519\|ssh-rsa' docker/setup_remote_connection.sh; then
+    pass "setup_remote_connection.sh validates SSH key format (CQ-029)"
+else
+    fail "setup_remote_connection.sh missing SSH key validation"
+fi
+
+# BP-026: CONTRIBUTING.md uses correct convention
+if grep -q 'set -euo pipefail' CONTRIBUTING.md; then
+    pass "CONTRIBUTING.md recommends set -euo pipefail (BP-026)"
+else
+    fail "CONTRIBUTING.md still recommends only set -e"
+fi
+
+# UX-024: $userName quoted in docker exec
+if grep -q '"\$userName"' scripts/launch_claude.ps1 2>/dev/null || grep -q 'userName`"' scripts/launch_claude.ps1 2>/dev/null; then
+    pass "launch_claude.ps1 quotes \$userName in docker exec (UX-024)"
+else
+    fail "launch_claude.ps1 has unquoted \$userName"
+fi
+
 echo ""
 echo "========================================="
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Phase 7 — final batch of audit findings actionable without Windows testing. Resolves 7 findings.

### Security
- **SEC-005/DEP-017**: Remove unused `pipx` installation from Dockerfile (dead dependency)
- **CQ-029**: Add SSH key format validation in `setup_remote_connection.sh` (validates ssh-rsa, ssh-ed25519, ecdsa-sha2 prefixes before writing to authorized_keys)
- **UX-024**: Quote `$userName` in all docker exec commands across `launch_claude.ps1` and `launch_vibe_kanban.ps1` (13 occurrences)

### Bug fixes
- **CQ-024**: Update `Fix-LineEndings` file lists — remove deleted `claude_wrapper.sh`, add all current docker scripts (both `setup_utils.ps1` and `fix_line_endings.ps1`)

### Documentation
- **BP-026**: Fix CONTRIBUTING.md — recommend `set -euo pipefail` to match actual project convention
- **UX-020**: Consistent Vibe Kanban description across AI_Docker_Launcher.ps1 and AI_Docker_Complete.ps1

### Tests
- 5 new bash structural assertions (38 total): pipx removal, stale references, SSH validation, docs, quoting

### Note on DEP-020 (apt version pinning)
Assessed and intentionally deferred — pinning apt packages in this context adds maintenance burden without proportional benefit. The base image is already SHA256-pinned for reproducibility.

## Test plan
- [x] Bash structural tests pass (38 assertions)
- [x] Auth persistence tests pass (26)
- [x] Vibe Kanban tests pass (23)
- [x] `bash -n docker/setup_remote_connection.sh` passes
- [x] No `claude_wrapper` references in setup_utils.ps1 or fix_line_endings.ps1

🤖 Generated with [Claude Code](https://claude.com/claude-code)