### PR TITLE
chore: prepare v1.2.4 release — dependency refresh + anti-rot CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Keep GitHub Actions pins current (security + Node runtime deprecations)
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC — keeps the pinned-version check running
+    # even when the repo is idle, so stale tool pins get flagged
+    - cron: '0 6 * * 1'
 
 # Restrict token to read-only — CI does not need write access
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,5 @@ npm-debug.log*
 # Secrets
 .secrets/
 
-# Claude
-CLAUDE.md
+# Claude (root-level personal context file only — docs/CLAUDE.md is tracked project documentation)
+/CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-07-01
+
+Dependency refresh release. Force Rebuild recommended to pick up the updated tools.
+
+### Changed
+- **Updated pinned AI CLI tool versions** (fresh installs and rebuilds were getting months-old tools):
+  - `@openai/codex` 0.98.0 → 0.142.5
+  - `@google/gemini-cli` 0.27.3 → 0.49.0
+  - `vibe-kanban` 0.1.7 → 0.1.44
+  - `openai` (pip) 2.18.0 → 2.44.0
+- **Refreshed Ubuntu 24.04 base image digest** to pull in upstream security patches
+
+### Added
+- **Weekly scheduled CI run** (Mondays 06:00 UTC) so the pinned-version check flags stale tools even when the repo is idle
+- **Dependabot for GitHub Actions** — keeps workflow action pins current automatically (also resolves the Node 20 runtime deprecation warnings)
+
+### Fixed
+- **`docs/CLAUDE.md` was never in the repository**: the `.gitignore` pattern `CLAUDE.md` (meant for a personal root-level context file) also matched `docs/CLAUDE.md`, so the project's developer context doc only existed locally and `docs/DEVELOPMENT.md` linked to a missing file. The rule is now anchored to the root (`/CLAUDE.md`) and the docs copy is tracked
+
 ## [1.2.3] - 2026-07-01
 
 Maintenance release shipping the full-application audit remediation (131 findings reviewed across UI/UX, security, dependencies, best practices, and code quality — PRs #43–#50). No new features and no migration steps required.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/Cainmani/ai-docker-sandbox/releases/latest">
-    <img src="https://img.shields.io/badge/Download-v1.2.3-brightgreen?style=for-the-badge&logo=windows" alt="Download Latest Release">
+    <img src="https://img.shields.io/badge/Download-v1.2.4-brightgreen?style=for-the-badge&logo=windows" alt="Download Latest Release">
   </a>
   &nbsp;
   <a href="LICENSE">

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # ai-docker/Dockerfile
 # Pinned: 2026-02-19 — refresh quarterly via: docker manifest inspect ubuntu:24.04
-FROM ubuntu:24.04@sha256:d1e2e92c075e5ca139d51a140fff46f84315c0fdce203eab2807c7e495eff4f9
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/install_cli_tools.sh
+++ b/docker/install_cli_tools.sh
@@ -388,7 +388,7 @@ install_cli_tools() {
     print_status "Installing Google Gemini CLI..."
     if npm view @google/gemini-cli version >/dev/null 2>&1; then
         print_status "Found @google/gemini-cli in npm registry"
-        if npm_install_with_retry "@google/gemini-cli@0.27.3" "/tmp/gemini_install.log"; then
+        if npm_install_with_retry "@google/gemini-cli@0.49.0" "/tmp/gemini_install.log"; then
             print_success "Gemini CLI installed successfully"
         else
             # Try community version as fallback
@@ -423,7 +423,7 @@ install_cli_tools() {
     # with no system Python packages that could conflict. The flag is required on Ubuntu 24.04+
     # which uses PEP 668 to prevent accidental system package modifications on host systems.
     if ! pip3 show openai >/dev/null 2>&1; then
-        if pip_install_with_retry "openai==2.18.0" "--break-system-packages"; then
+        if pip_install_with_retry "openai==2.44.0" "--break-system-packages"; then
             print_success "OpenAI Python SDK installed"
         else
             print_warning "Failed to install OpenAI Python SDK"
@@ -438,7 +438,7 @@ install_cli_tools() {
     update_install_status "OpenAI Codex CLI" "npm"
     print_status "Installing OpenAI Codex CLI..."
     if npm view @openai/codex version >/dev/null 2>&1; then
-        if npm_install_with_retry "@openai/codex@0.98.0" "/tmp/codex_install.log"; then
+        if npm_install_with_retry "@openai/codex@0.142.5" "/tmp/codex_install.log"; then
             print_success "OpenAI Codex CLI installed successfully"
         else
             print_warning "OpenAI Codex CLI installation failed - can be installed manually with: npm install -g @openai/codex"
@@ -453,7 +453,7 @@ install_cli_tools() {
 
     # 5. Install Vibe Kanban (AI agent orchestration tool)
     update_install_status "Vibe Kanban" "npm"
-    if npm_install_with_retry "vibe-kanban@0.1.7" "/tmp/vibe_kanban_install.log"; then
+    if npm_install_with_retry "vibe-kanban@0.1.44" "/tmp/vibe_kanban_install.log"; then
         print_success "Vibe Kanban installed successfully"
         # Create .vibe-kanban directory for data persistence
         mkdir -p "${HOME}/.vibe-kanban"
@@ -522,7 +522,7 @@ update_cli_tools() {
 
     # Update pip packages (only currently installed tools)
     print_status "Updating Python packages..."
-    pip3 install --user --upgrade openai==2.18.0 --quiet || true
+    pip3 install --user --upgrade openai==2.44.0 --quiet || true
 
     # Update GitHub CLI
     if command_exists gh; then

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,208 @@
+# Claude AI Context File - AI Docker CLI Manager Project
+
+**Last Updated:** July 1, 2026
+**Project Version:** 1.2.4
+
+---
+
+## Project Overview
+
+AI Docker CLI Manager is a Windows .exe that sets up a Docker container with multiple AI CLI tools pre-installed. Users run a setup wizard, which builds a Docker image, creates a container, and installs all tools automatically.
+
+### Architecture
+
+```
+Windows (.exe)                          Docker Container (Linux)
+┌─────────────────────┐                ┌──────────────────────────┐
+│ AI_Docker_Complete   │  builds/runs  │ entrypoint.sh            │
+│   ├─ setup_wizard    │──────────────>│   ├─ install_cli_tools   │
+│   ├─ launch_claude   │  docker exec  │   ├─ configure_tools     │
+│   └─ launch_vibe     │──────────────>│   └─ auto_update         │
+└─────────────────────┘                └──────────────────────────┘
+```
+
+### How the .exe Works
+
+1. `AI_Docker_Complete.ps1` is the template — all project files are Base64-embedded at build time
+2. `build_complete_exe.ps1` reads files, encodes them, replaces placeholders, compiles via ps2exe
+3. At runtime, the .exe extracts Docker files to `%LOCALAPPDATA%\AI-Docker-CLI\docker-files\`
+4. Setup wizard runs as a separate PowerShell process from that directory
+
+### Installed AI Tools
+
+| Tool | Command | Install Method |
+|------|---------|----------------|
+| Claude Code CLI | `claude` | Native installer (`~/.local/bin/claude`) |
+| GitHub CLI | `gh` | apt |
+| Google Gemini CLI | `gemini` | npm (`@google/gemini-cli`) |
+| OpenAI Codex CLI | `codex` | npm (`@openai/codex`) |
+| OpenAI Python SDK | `python3 -c "import openai"` | pip |
+| Vibe Kanban | `vibe-kanban` | npm |
+
+---
+
+## Key Architecture Decisions
+
+### Auth Persistence (v1.2.2)
+
+Credentials persist across container rebuilds via Docker volumes + symlinks:
+
+| Volume | Persists |
+|--------|----------|
+| `claude-config` | `~/.claude/` (OAuth creds, settings, conversations) |
+| `tool-auth` | `~/.config/gh/`, `~/.config/openai/`, `~/.config/gemini/`, `~/.config/shell_gpt/`, `~/.codex/` |
+
+`~/.claude.json` (onboarding flag) is symlinked into the `claude-config` volume.
+Each tool config dir is symlinked into the `tool-auth` volume (e.g., `~/.config/gh` → `~/.tool-auth/gh`).
+
+### Shell Script Strict Mode
+
+All shell scripts use `set -euo pipefail`. This means:
+- **Always use `${VAR:-}` for optional variables** (not `$VAR`)
+- **Always use `${1:-}` for optional positional args** (not `$1`)
+- Unguarded variables cause immediate script termination
+
+### Install Marker
+
+`~/.cli_tools_installed` is created only after successful installation. The entrypoint does NOT use an EXIT trap for this — if the script crashes, the marker is not created, allowing retries on next start.
+
+### Log Sanitization
+
+All logging functions sanitize before writing to disk:
+- **PowerShell**: `Sanitize-LogMessage` in each script (redacts Windows username, container username, API keys, tokens)
+- **Shell**: `sanitize_message()` in `lib/logging.sh` (same patterns)
+- Fallback logging paths also sanitize
+
+---
+
+## Build System
+
+### Adding a New File to the .exe
+
+When adding a new file that must be embedded in the .exe, update ALL of these:
+
+1. **`scripts/build/build_complete_exe.ps1`** — add to `$filesToEmbed` array
+2. **`scripts/AI_Docker_Complete.ps1`** — add to `$script:EmbeddedFiles` hashtable with `FILENAME_EXT_BASE64_HERE` placeholder
+3. **`scripts/AI_Docker_Complete.ps1`** — if it's a script dependency (like `wsl_config.ps1`), add extraction logic where it's needed
+4. **`docker/Dockerfile`** — add COPY and chmod if it goes in the container
+5. **`scripts/fix_line_endings.ps1`** — add `.sh` files to the line endings fixer
+
+### Build & Release Process
+
+```bash
+# After merging to main:
+git tag v1.X.Y
+git push origin v1.X.Y
+# GitHub Actions builds the .exe and creates the release automatically
+```
+
+### Docker Build Cache
+
+When shell scripts change but the Dockerfile doesn't, Docker may serve cached COPY layers. Users need **Force Rebuild** (which passes `--no-cache`) to pick up script changes.
+
+---
+
+## Developer Mode
+
+Mount scripts directly from host for live editing (no rebuild needed):
+
+```bash
+# In docker/.env:
+DEV_MODE=1
+
+# Then:
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+```
+
+Scripts are mounted read-only. Only for local development.
+
+---
+
+## File Structure
+
+### Windows-side (PowerShell)
+
+| File | Purpose |
+|------|---------|
+| `scripts/AI_Docker_Complete.ps1` | Main app template with embedded files |
+| `scripts/AI_Docker_Launcher.ps1` | Lightweight launcher (no setup wizard) |
+| `scripts/setup_wizard.ps1` | WinForms setup wizard |
+| `scripts/wsl_config.ps1` | WSL detection functions (dot-sourced by wizard) |
+| `scripts/launch_claude.ps1` | Launches Docker exec terminal |
+| `scripts/launch_vibe_kanban.ps1` | Launches Vibe Kanban web UI |
+| `scripts/build/build_complete_exe.ps1` | Builds the .exe from template |
+
+### Container-side (Bash)
+
+| File | Purpose |
+|------|---------|
+| `docker/entrypoint.sh` | Container init: user setup, volumes, .bashrc, tool install |
+| `docker/install_cli_tools.sh` | Installs all CLI tools (runs on first start) |
+| `docker/configure_tools.sh` | Interactive tool configuration wizard |
+| `docker/auto_update.sh` | Weekly auto-update via cron |
+| `docker/lib/logging.sh` | Centralized logging with sanitization and rotation |
+
+### Docker Volumes
+
+| Volume | Mount | Purpose |
+|--------|-------|---------|
+| `claude-config` | `~/.claude` | Claude credentials, settings, conversations |
+| `tool-auth` | `~/.tool-auth` | Auth configs for gh, openai, gemini, codex, shell_gpt |
+| `workspace` | `/workspace` | User's project files (bind mount to host) |
+| `vibe-kanban-data` | `~/.vibe-kanban` | Vibe Kanban state |
+| `ssh-keys` | `~/.ssh` | SSH keys for mobile access |
+
+---
+
+## PowerShell Gotchas
+
+- **`-match`/`-notmatch` are case-insensitive** — use `-cmatch`/`-cnotmatch` for case-sensitive matching
+- **`$PSScriptRoot`** — directory of the running script, NOT the working directory
+- **WinForms runs in a separate process** — setup wizard is launched via `Start-Process powershell.exe`
+- **Dot-sourced files must exist at `$PSScriptRoot`** — the .exe must extract dependencies alongside the script
+
+---
+
+## CI/CD
+
+### GitHub Actions Workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `ci.yml` | Push/PR to main | PowerShell syntax check, Pester tests, Dockerfile validation, pinned version check |
+| `release.yml` | Push `v*.*.*` tag | Builds .exe on windows-latest, creates GitHub release with checksum |
+
+### Pester Tests
+
+`tests/WSLConfig.Tests.ps1` — tests for `wsl_config.ps1` functions (RAM detection, CPU detection, profile recommendation, config parsing).
+
+---
+
+## Git Configuration
+
+### Author Email (IMPORTANT)
+
+Commits must use the personal GitHub noreply email so they're attributed to the correct account:
+
+```
+git config user.email "100510814+CaideSpries@users.noreply.github.com"
+```
+
+A pre-commit hook in `.git/hooks/pre-commit` enforces this — commits will be rejected if the email is wrong. If you clone fresh, the hook needs to be recreated (git hooks aren't tracked).
+
+**Why:** The old email `Cainmani@users.noreply.github.com` attributes commits to the org account, not the personal GitHub profile.
+
+---
+
+## Version Bump Checklist
+
+Before creating a release:
+
+- [ ] `scripts/AI_Docker_Complete.ps1` — `$script:AppVersion = "X.Y.Z"`
+- [ ] `scripts/AI_Docker_Launcher.ps1` — `$script:AppVersion = "X.Y.Z"`
+- [ ] `scripts/build/build_complete_exe.ps1` — ps2exe `-version "X.Y.Z.0"`
+- [ ] `README.md` — download badge version
+- [ ] `CHANGELOG.md` — new version section
+- [ ] `docs/MIGRATION.md` — version history row
+- [ ] `docs/CLAUDE.md` — project version + last updated date
+- [ ] Docs updated if user-facing features changed

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -128,6 +128,7 @@ curl -fsSL https://claude.ai/install.sh | sh
 
 | Version | Date | Breaking Changes |
 |---------|------|------------------|
+| v1.2.4 | 2026-07 | None — dependency refresh (force rebuild recommended to get updated AI CLI tools) |
 | v1.2.3 | 2026-07 | None — audit remediation release (force rebuild recommended to pick up container script fixes) |
 | v1.2.2 | 2026-02 | None — credentials now persist across rebuilds (force rebuild recommended to pick up fixes) |
 | v1.1.3 | 2026-01 | Claude Code migrated to native installer (requires force rebuild + one-time re-auth) |

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -92,7 +92,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.2.3"
+$script:AppVersion = "1.2.4"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -19,7 +19,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.2.3"
+$script:AppVersion = "1.2.4"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/build/build_complete_exe.ps1
+++ b/scripts/build/build_complete_exe.ps1
@@ -160,7 +160,7 @@ try {
         -description "Complete AI CLI Docker Setup System" `
         -company "AI Docker Sandbox" `
         -product "AI Docker CLI Setup" `
-        -version "1.2.3.0" `
+        -version "1.2.4.0" `
         -noConsole
 
     if (Test-Path $exePath) {


### PR DESCRIPTION
## Summary

Ships the improvements agreed after v1.2.3: refresh the stale AI tool pins (the direct coding-experience win) and make the repo resistant to silent staleness.

### Changes
- **Pinned AI CLI tools updated** (fresh installs/rebuilds were getting months-old tools):
  | Tool | Old | New |
  |------|-----|-----|
  | `@openai/codex` | 0.98.0 | 0.142.5 |
  | `@google/gemini-cli` | 0.27.3 | 0.49.0 |
  | `vibe-kanban` | 0.1.7 | 0.1.44 |
  | `openai` (pip) | 2.18.0 | 2.44.0 |

  All versions verified against npm/PyPI registries.
- **Ubuntu 24.04 base image digest refreshed** for upstream security patches
- **Weekly scheduled CI** (Mondays 06:00 UTC) — the pinned-version check now runs even when nobody pushes
- **Dependabot for GitHub Actions** — keeps action pins current (also resolves the Node 20 deprecation warnings from the release build)
- **Fix: `docs/CLAUDE.md` was never actually in the repo** — the bare `CLAUDE.md` gitignore pattern matched it, so the developer context doc existed only locally and `DEVELOPMENT.md` linked to a missing file. Rule anchored to `/CLAUDE.md`, docs copy now tracked
- Version bumped to 1.2.4 everywhere (launchers, build metadata, README badge, docs)

### Verification
- All three bash test suites pass (syntax + structural assertions)
- `bash -n` clean on modified shell scripts

### After merge
Tag `v1.2.4` → release workflow builds and publishes the new .exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)