### PR TITLE
feat: add 9router/OmniRoute AI routers + fix dashboard reachability (v1.3.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,16 @@ jobs:
           gemini_ver=$(grep -oP '@google/gemini-cli@\K[0-9.]+' "$SCRIPT" | head -1)
           codex_ver=$(grep -oP '@openai/codex@\K[0-9.]+' "$SCRIPT" | head -1)
           vibe_ver=$(grep -oP 'vibe-kanban@\K[0-9.]+' "$SCRIPT" | head -1)
+          ninerouter_ver=$(grep -oP '9router@\K[0-9.]+' "$SCRIPT" | head -1)
+          omniroute_ver=$(grep -oP 'omniroute@\K[0-9.]+' "$SCRIPT" | head -1)
           openai_ver=$(grep -oP 'openai==\K[0-9.]+' "$SCRIPT" | head -1)
 
           echo "Pinned versions found in $SCRIPT:"
           echo "  @google/gemini-cli: ${gemini_ver:-NOT FOUND}"
           echo "  @openai/codex: ${codex_ver:-NOT FOUND}"
           echo "  vibe-kanban: ${vibe_ver:-NOT FOUND}"
+          echo "  9router: ${ninerouter_ver:-NOT FOUND}"
+          echo "  omniroute: ${omniroute_ver:-NOT FOUND}"
           echo "  openai (pip): ${openai_ver:-NOT FOUND}"
           echo ""
 
@@ -240,6 +244,8 @@ jobs:
           [ -n "$gemini_ver" ] && check_npm "@google/gemini-cli" "$gemini_ver"
           [ -n "$codex_ver" ] && check_npm "@openai/codex" "$codex_ver"
           [ -n "$vibe_ver" ] && check_npm "vibe-kanban" "$vibe_ver"
+          [ -n "$ninerouter_ver" ] && check_npm "9router" "$ninerouter_ver"
+          [ -n "$omniroute_ver" ] && check_npm "omniroute" "$omniroute_ver"
           [ -n "$openai_ver" ] && check_pip "openai" "$openai_ver"
 
           echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-07
+
+Adds unified AI router tools (9router / OmniRoute) and fixes reaching their dashboards from the Windows host browser. Force Rebuild recommended so the container picks up the new tools and the updated port mapping.
+
+### Added
+- **9router and OmniRoute now install automatically** alongside the other CLI tools. These unified "AI router" gateways expose multiple AI subscriptions behind one OpenAI-compatible endpoint. Pinned to `9router@0.5.18` and `omniroute@3.8.45`; both are the real npm packages (not forked) and update via the weekly container tool updater.
+- **"AI Router" entry in `configure-tools`** (option 6). 9router and OmniRoute are interchangeable and share one dashboard port, so the wizard runs only one at a time: pick a router, it stops any other and starts the chosen one bound to `0.0.0.0`, then prints the dashboard URL. `config-status` shows the slot as configured once either is installed.
+- **Router data now persists across rebuilds.** A new `router-data` Docker volume holds each router's SQLite DB and linked-provider credentials (`DATA_DIR=~/.router-data/<tool>`, a separate subdir per tool), so you don't have to re-link your subscriptions after a Force Rebuild.
+
+### Fixed
+- **9router / OmniRoute dashboards were unreachable from the host browser** (`localhost:20128` refused to connect). Two root causes, both addressed:
+  - The port was never published from the container — `docker-compose.yml` now publishes the shared router port (`AI_ROUTER_PORT`, default `20128`).
+  - The routers bind to `localhost` (127.0.0.1) inside the container by default, which Docker's published port cannot reach — the `~/.bashrc` `9router`/`omniroute` wrappers now launch the real binaries bound to `0.0.0.0`, and stop any other router first so the shared port never double-binds.
+
+### Notes
+- Recreate the container to pick up the new port mapping and volume: `docker compose up -d --force-recreate` (or Force Rebuild in the launcher). Your workspace, tool logins, and router subscriptions persist — they live on mounted volumes, not in the container layer.
+
 ## [1.2.4] - 2026-07-01
 
 Dependency refresh release. Force Rebuild recommended to pick up the updated tools.

--- a/docker/configure_tools.sh
+++ b/docker/configure_tools.sh
@@ -84,6 +84,13 @@ is_configured() {
                 return 0  # API key fallback
             fi
             ;;
+        ai_router)
+            # 9router / OmniRoute are configured in their web dashboard (you link each AI
+            # subscription there), not via a CLI key. Treat "either installed" as ready-to-use.
+            if npm list -g 9router >/dev/null 2>&1 || npm list -g omniroute >/dev/null 2>&1; then
+                return 0
+            fi
+            ;;
     esac
     return 1
 }
@@ -327,6 +334,101 @@ TOML
     fi
 }
 
+# Function to configure the AI router slot (9router / OmniRoute)
+# 9router and OmniRoute are interchangeable unified-router tools that share one dashboard port,
+# so only ONE runs at a time. This helper shows which (if any) is running, lets the user pick
+# one, stops any other router, and starts the chosen one bound to 0.0.0.0 so the host browser
+# can reach it. Subscriptions are linked inside the dashboard, not from this menu.
+configure_ai_router() {
+    print_header "Configure AI Router (9router / OmniRoute)"
+    config_log "INFO" "User initiated AI router configuration"
+
+    local port="${AI_ROUTER_PORT:-20128}"
+
+    # Which routers are installed?
+    local have_9router=false have_omniroute=false
+    npm list -g 9router   >/dev/null 2>&1 && have_9router=true
+    npm list -g omniroute >/dev/null 2>&1 && have_omniroute=true
+
+    if [ "$have_9router" = false ] && [ "$have_omniroute" = false ]; then
+        print_error "Neither 9router nor OmniRoute is installed"
+        echo ""
+        echo "They normally install automatically during setup - try 'update-container-tools',"
+        echo "or install manually: npm install -g 9router   (or)   npm install -g omniroute"
+        echo ""
+        read -rp "Press Enter to continue..." _
+        return 1
+    fi
+
+    print_status "9router and OmniRoute both link multiple AI subscriptions behind one"
+    print_status "OpenAI-compatible endpoint. They share port $port, so only one runs at a time."
+    echo ""
+    echo "  Note: you sign into each AI provider in the router's web dashboard - not here."
+    echo ""
+
+    # Report which router (if any) is currently running
+    local running=""
+    if pgrep -f '9router'   >/dev/null 2>&1; then running="9router"; fi
+    if pgrep -f 'omniroute' >/dev/null 2>&1; then running="omniroute"; fi
+    if [ -n "$running" ]; then
+        print_success "Currently running: $running  ->  http://localhost:$port/dashboard"
+        echo ""
+    fi
+
+    # Offer only the installed routers
+    echo "Which router do you want to run?"
+    [ "$have_9router"   = true ] && echo "  1. 9router"
+    [ "$have_omniroute" = true ] && echo "  2. OmniRoute"
+    echo "  0. Keep current / skip"
+    echo ""
+    read -rp "Enter your choice: " router_choice
+
+    local tool=""
+    case "$router_choice" in
+        1) if [ "$have_9router" = true ];   then tool="9router";   else print_error "9router is not installed";   read -rp "Press Enter to continue..." _; return 1; fi ;;
+        2) if [ "$have_omniroute" = true ]; then tool="omniroute"; else print_error "OmniRoute is not installed"; read -rp "Press Enter to continue..." _; return 1; fi ;;
+        0|"") print_status "No change."; read -rp "Press Enter to continue..." _; return 0 ;;
+        *) print_error "Invalid choice"; read -rp "Press Enter to continue..." _; return 1 ;;
+    esac
+
+    # Stop whichever router is running (enforces one-at-a-time), then start the chosen one.
+    print_status "Stopping any running router..."
+    pkill -f '9router'   2>/dev/null || true
+    pkill -f 'omniroute' 2>/dev/null || true
+    sleep 1
+
+    print_status "Starting $tool on 0.0.0.0:$port ..."
+    config_log "INFO" "AI router: starting $tool on port $port"
+    # Bind 0.0.0.0 (not localhost) so Docker's published port reaches it. DATA_DIR points at the
+    # tool's own persisted data dir (survives rebuilds). Detached.
+    local data_dir="$HOME/.router-data/$tool"
+    mkdir -p "$data_dir"
+    HOST=0.0.0.0 HOSTNAME=0.0.0.0 PORT="$port" DATA_DIR="$data_dir" nohup "$tool" > "/tmp/$tool.log" 2>&1 &
+    disown 2>/dev/null || true
+
+    # Wait for it to listen (first run may download assets)
+    local waited=0
+    while [ $waited -lt 30 ]; do
+        netstat -tlnp 2>/dev/null | grep -q ":$port " && break
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if netstat -tlnp 2>/dev/null | grep -q ":$port "; then
+        print_success "$tool started."
+        config_log "INFO" "AI router: $tool started on port $port"
+    else
+        print_warning "$tool did not report ready within 30s - it may still be starting."
+        print_warning "Check /tmp/$tool.log for details."
+        config_log "WARN" "AI router: $tool not listening within timeout on port $port"
+    fi
+    echo ""
+    echo "  Open the dashboard from your host browser and link your subscriptions there:"
+    echo "    http://localhost:$port/dashboard"
+    echo ""
+    read -rp "Press Enter to continue..." _
+}
+
 # Function to show configuration status
 show_status() {
     print_header "CLI Tools Configuration Status"
@@ -338,6 +440,7 @@ show_status() {
         "openai:OpenAI/GPT Tools"
         "codex:OpenAI Codex CLI"
         "gemini:Google Gemini"
+        "ai_router:AI Router (9router / OmniRoute)"
     )
 
     for tool_info in "${tools[@]}"; do
@@ -371,11 +474,12 @@ interactive_configure() {
         echo "3. OpenAI/GPT Tools (Python SDK)"
         echo "4. OpenAI Codex CLI"
         echo "5. Google Gemini"
+        echo "6. AI Router (9router / OmniRoute)"
         echo "A. Configure All"
         echo "0. Exit"
         echo ""
 
-        read -rp "Enter your choice (0-5, A): " choice
+        read -rp "Enter your choice (0-6, A): " choice
 
         case $choice in
             1) configure_claude ;;
@@ -383,12 +487,14 @@ interactive_configure() {
             3) configure_openai ;;
             4) configure_codex ;;
             5) configure_gemini ;;
+            6) configure_ai_router ;;
             [Aa])
                 configure_claude
                 configure_github
                 configure_openai
                 configure_codex
                 configure_gemini
+                configure_ai_router
                 show_status
                 ;;
             0)
@@ -424,12 +530,16 @@ case "${1:-}" in
     --codex)
         configure_codex
         ;;
+    --ai-router|--9router|--omniroute)
+        configure_ai_router
+        ;;
     --all)
         configure_claude
         configure_github
         configure_openai
         configure_codex
         configure_gemini
+        configure_ai_router
         show_status
         ;;
     --help|-h)
@@ -442,6 +552,7 @@ case "${1:-}" in
         echo "  --openai, --gpt  Configure OpenAI/GPT tools (Python SDK)"
         echo "  --codex          Configure OpenAI Codex CLI"
         echo "  --gemini         Configure Google Gemini"
+        echo "  --ai-router      Choose/start the AI router (9router or OmniRoute)"
         echo "  --all            Configure all tools"
         echo "  --help, -h       Show this help message"
         echo ""

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       USER_NAME: ${USER_NAME}
       # Vibe Kanban configuration
       VIBE_KANBAN_PORT: ${VIBE_KANBAN_PORT:-3000}
+      # AI router dashboard port (shared by 9router and OmniRoute - only one runs at a time)
+      AI_ROUTER_PORT: ${AI_ROUTER_PORT:-20128}
       # Force CLI tools reinstallation (set by setup wizard when Force Rebuild is checked)
       FORCE_CLI_REINSTALL: ${FORCE_CLI_REINSTALL:-}
       # Mobile access configuration (SSH + Mosh + tmux)
@@ -21,6 +23,9 @@ services:
     ports:
       # Vibe Kanban web UI - accessible from Windows browser at http://localhost:3000
       - "${VIBE_KANBAN_PORT:-3000}:${VIBE_KANBAN_PORT:-3000}"
+      # AI router dashboard (9router or OmniRoute) - reachable from the Windows browser at
+      # http://localhost:20128/dashboard. One shared port; only one router runs at a time.
+      - "${AI_ROUTER_PORT:-20128}:${AI_ROUTER_PORT:-20128}"
       # SSH for mobile access (only exposed when ENABLE_MOBILE_ACCESS=1)
       - "${SSH_PORT:-2222}:${SSH_PORT:-2222}"
       # Mosh UDP ports for persistent mobile connections (5 concurrent connections)
@@ -34,6 +39,8 @@ services:
       - ssh-keys:/home/${USER_NAME}/.ssh
       # Tool auth persistence (survives container rebuilds)
       - tool-auth:/home/${USER_NAME}/.tool-auth
+      # AI router data persistence (9router / OmniRoute SQLite DB + linked provider credentials)
+      - router-data:/home/${USER_NAME}/.router-data
     tty: true
     stdin_open: true
     healthcheck:
@@ -62,4 +69,6 @@ volumes:
   ssh-keys:
     driver: local
   tool-auth:
+    driver: local
+  router-data:
     driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -188,6 +188,14 @@ chown -R "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.config"
 chown -h "$USER_NAME:$USER_NAME" "$CODEX_CONFIG"
 entrypoint_log "INFO" "Tool-auth persistence setup complete"
 
+# Ensure the AI router data volume exists with correct ownership. 9router and OmniRoute each
+# keep their SQLite DB + linked-provider credentials under their own subdir (DATA_DIR is set to
+# these by the launch wrappers), so both persist across container rebuilds without clashing.
+entrypoint_log "INFO" "Setting up AI router data persistence"
+ROUTER_DATA_DIR="/home/$USER_NAME/.router-data"
+mkdir -p "$ROUTER_DATA_DIR/9router" "$ROUTER_DATA_DIR/omniroute"
+chown -R "$USER_NAME:$USER_NAME" "$ROUTER_DATA_DIR"
+
 # Configure npm to use user-local directory for global packages
 su - "$USER_NAME" -c "mkdir -p /home/$USER_NAME/.npm-global"
 su - "$USER_NAME" -c "npm config set prefix '/home/$USER_NAME/.npm-global'"
@@ -251,6 +259,8 @@ if [ -f "$HOME/.cli_tools_installed" ]; then
   echo "|   * gemini       - Google Gemini CLI                        |"
   echo "|   * codex        - OpenAI Codex CLI                         |"
   echo "|   * python3      - OpenAI Python SDK (import openai)        |"
+  echo "|   * 9router      - Unified AI router (dashboard :20128)     |"
+  echo "|   * omniroute    - Unified AI router (alt. to 9router)      |"
   echo "|                                                             |"
   echo "| Management Commands:                                        |"
   echo "|   * configure-tools         - Set up API keys/authentication|"
@@ -284,6 +294,30 @@ else
     echo 'export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"' >> "/home/$USER_NAME/.bashrc"
     chown "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.bashrc"
   fi
+fi
+
+# Ensure the AI router dashboards (9router / OmniRoute) bind to 0.0.0.0 so they are reachable
+# from the Windows host. Both are Next.js apps that bind to localhost (127.0.0.1) inside the
+# container by default, which Docker's published port cannot reach. These wrappers inject
+# HOST/HOSTNAME=0.0.0.0 and the shared port only for the router process - no global pollution.
+# They call the real npm-installed binaries via `command`, so normal updates
+# (npm update -g ...) apply unchanged - nothing here is a fork.
+#
+# 9router and OmniRoute are interchangeable and share one port, so only ONE runs at a time.
+# Each wrapper stops any router already running before starting, so switching is seamless and
+# the port never double-binds. Idempotent + applied to both fresh and pre-existing .bashrc.
+if ! grep -q "^9router()" "/home/$USER_NAME/.bashrc" 2>/dev/null; then
+  cat >> "/home/$USER_NAME/.bashrc" << 'EOF'
+
+# AI router wrappers (9router / OmniRoute): bind the dashboard to 0.0.0.0 so it is reachable
+# from the host browser at http://localhost:20128/dashboard (port overridable via
+# AI_ROUTER_PORT). DATA_DIR points each router at its own persisted data dir. Only one router
+# runs at a time - starting one stops the other.
+__ai_router_stop() { pkill -f '9router' 2>/dev/null; pkill -f 'omniroute' 2>/dev/null; return 0; }
+9router()   { __ai_router_stop; mkdir -p "$HOME/.router-data/9router";   HOST=0.0.0.0 HOSTNAME=0.0.0.0 PORT="${AI_ROUTER_PORT:-20128}" DATA_DIR="$HOME/.router-data/9router"   command 9router "$@"; }
+omniroute() { __ai_router_stop; mkdir -p "$HOME/.router-data/omniroute"; HOST=0.0.0.0 HOSTNAME=0.0.0.0 PORT="${AI_ROUTER_PORT:-20128}" DATA_DIR="$HOME/.router-data/omniroute" command omniroute "$@"; }
+EOF
+  chown "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.bashrc"
 fi
 
 # Create .profile to set PATH for login shells (used by 'su -')

--- a/docker/install_cli_tools.sh
+++ b/docker/install_cli_tools.sh
@@ -248,6 +248,12 @@ get_version() {
         vibe-kanban)
             npm list -g vibe-kanban 2>/dev/null | grep 'vibe-kanban' | cut -d'@' -f2 || echo "not installed"
             ;;
+        9router)
+            npm list -g 9router 2>/dev/null | grep '9router' | cut -d'@' -f2 || echo "not installed"
+            ;;
+        omniroute)
+            npm list -g omniroute 2>/dev/null | grep 'omniroute' | cut -d'@' -f2 || echo "not installed"
+            ;;
         *)
             echo "unknown"
             ;;
@@ -262,6 +268,8 @@ save_versions() {
     echo "gemini=$(get_version gemini)" >> "$TOOLS_VERSION_FILE"
     echo "codex=$(get_version codex)" >> "$TOOLS_VERSION_FILE"
     echo "vibe-kanban=$(get_version vibe-kanban)" >> "$TOOLS_VERSION_FILE"
+    echo "9router=$(get_version 9router)" >> "$TOOLS_VERSION_FILE"
+    echo "omniroute=$(get_version omniroute)" >> "$TOOLS_VERSION_FILE"
 }
 
 # Main installation function
@@ -461,6 +469,26 @@ install_cli_tools() {
         print_warning "Vibe Kanban installation failed - can be installed manually with: npm install -g vibe-kanban"
     fi
 
+    # 6. Install 9router (unified AI API router - links multiple AI subscriptions behind one
+    # OpenAI-compatible endpoint; web dashboard served on port 20128, bound to 0.0.0.0 by the
+    # 9router() wrapper in ~/.bashrc so it is reachable from the Windows host browser)
+    update_install_status "9router" "npm"
+    if npm_install_with_retry "9router@0.5.18" "/tmp/9router_install.log"; then
+        print_success "9router installed successfully"
+    else
+        print_warning "9router installation failed - can be installed manually with: npm install -g 9router"
+    fi
+
+    # 7. Install OmniRoute (unified AI gateway - same family of tool as 9router; web dashboard
+    # served on port 20129 by default to avoid colliding with 9router's 20128, bound to 0.0.0.0
+    # by the omniroute() wrapper in ~/.bashrc so it is reachable from the Windows host browser)
+    update_install_status "OmniRoute" "npm"
+    if npm_install_with_retry "omniroute@3.8.45" "/tmp/omniroute_install.log"; then
+        print_success "OmniRoute installed successfully"
+    else
+        print_warning "OmniRoute installation failed - can be installed manually with: npm install -g omniroute"
+    fi
+
     # Save versions to file
     save_versions
 
@@ -504,6 +532,18 @@ create_marker_file() {
         echo "[OK] Vibe Kanban: installed" >> "$INSTALL_MARKER"
     else
         echo "[ERROR] Vibe Kanban: failed" >> "$INSTALL_MARKER"
+    fi
+
+    if npm list -g 9router >/dev/null 2>&1; then
+        echo "[OK] 9router: installed" >> "$INSTALL_MARKER"
+    else
+        echo "[ERROR] 9router: failed" >> "$INSTALL_MARKER"
+    fi
+
+    if npm list -g omniroute >/dev/null 2>&1; then
+        echo "[OK] OmniRoute: installed" >> "$INSTALL_MARKER"
+    else
+        echo "[ERROR] OmniRoute: failed" >> "$INSTALL_MARKER"
     fi
 
     print_success "Installation marker file created at: $INSTALL_MARKER"
@@ -575,6 +615,8 @@ cleanup_old_installations() {
     npm uninstall -g @google/gemini-cli 2>/dev/null || true
     npm uninstall -g @openai/codex 2>/dev/null || true
     npm uninstall -g vibe-kanban 2>/dev/null || true
+    npm uninstall -g 9router 2>/dev/null || true
+    npm uninstall -g omniroute 2>/dev/null || true
 
     # Clear npm cache to avoid stale package issues
     npm cache clean --force 2>/dev/null || true

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -92,7 +92,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.2.4"
+$script:AppVersion = "1.3.0"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -19,7 +19,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.2.4"
+$script:AppVersion = "1.3.0"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 


### PR DESCRIPTION
## Summary

Adds the **9router** and **OmniRoute** unified "AI router" gateways to the container toolset, and fixes their dashboards being unreachable from the Windows host browser (`localhost:20128` → `ERR_CONNECTION_REFUSED`).

### Why the dashboard was unreachable
Two stacked causes, both fixed:
1. The router port was **never published** from the container.
2. The routers **bind to `localhost` (127.0.0.1)** inside the container by default, which Docker's published port cannot reach.

### One router at a time
9router and OmniRoute are interchangeable and both default to port 20128, so running both is redundant and clashes. They now **share one port and only one runs at a time** — starting one stops the other. Both are installed so you can switch instantly.

## Changes
- **`docker-compose.yml`** — publish shared `AI_ROUTER_PORT` (default `20128`); add `router-data` volume.
- **`entrypoint.sh`** — `9router`/`omniroute` `~/.bashrc` wrappers bind `0.0.0.0`, set per-tool `DATA_DIR` (`~/.router-data/<tool>`), and stop the other router first; login banner lists both.
- **`install_cli_tools.sh`** — auto-install `9router@0.5.18` + `omniroute@3.8.45` (version tracking, cleanup, install marker).
- **`configure_tools.sh`** — new **"AI Router"** wizard entry (option 6): pick a router, it stops any other, starts the chosen one bound to `0.0.0.0`, and prints the dashboard URL.
- **`ci.yml`** — both pins tracked in the weekly staleness check.
- **Version bump `1.2.4` → `1.3.0`** + CHANGELOG.

The upstream npm packages are used **unchanged (not forked)**, so their normal updates still apply via the weekly container tool updater.

## Not forked / updates preserved
Both are the real npm packages; nothing patches their code. `update-container-tools` (`npm update -g`) keeps them current.

## Test / rollout notes
- Validated locally: `bash -n` on all changed scripts, compose parses as valid YAML (5 volumes, router port published), banner lines width-aligned, `9router`/`omniroute` bash function names verified.
- Not runtime-tested end-to-end (no container in the authoring env) — final "dashboard loads" proof is a **Force Rebuild** on a host.
- After merge + `v1.3.0` tag: users update the exe, then run **Force Rebuild** once to pick up the new port mapping + volume. Workspace, tool logins, and router subscriptions persist (all on mounted volumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)