### PR TITLE
Fix wizard timeout and PowerShell 5.1 compatibility in v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-07-07
+
+Fixes the scary-but-harmless errors the setup wizard showed after rebuilding for 1.3.0. No container changes - the container itself was installing fine; the wizard just gave up waiting too early and hit a PowerShell 5.1 incompatibility during cleanup.
+
+### Fixed
+- **Wizard timed out during CLI tool installation after the 1.3.0 rebuild** ("Installation is taking longer than expected", "Claude CLI not found yet"). The wizard only waited 5 minutes, but a Force Rebuild now installs 8 tools sequentially (9router and OmniRoute were added in 1.3.0), which routinely takes longer. The wait is now 10 minutes, and the timeout/verification messages explain that installation genuinely continues in the background (your shell shows an "Installing..." spinner until it finishes - `claude` and the other tools appear once it completes).
+- **"Secure replacement failed: RandomNumberGenerator does not contain a method named 'Fill'"** during password-file cleanup. `RandomNumberGenerator::Fill()` only exists in PowerShell 7 (.NET Core); Windows PowerShell 5.1 users hit the fallback path. Now uses `Create()`/`GetBytes()`, which works on both. The fallback did still replace the password with a placeholder, so no security impact - the overwrite passes just didn't run.
+
+### Changed
+- **Wizard install progress now tracks all 8 tools** (previously only the original 5), so the progress bar no longer stalls at 95% while Vibe Kanban, 9router, and OmniRoute install.
+
 ## [1.3.0] - 2026-07-07
 
 Adds unified AI router tools (9router / OmniRoute) and fixes reaching their dashboards from the Windows host browser. Force Rebuild recommended so the container picks up the new tools and the updated port mapping.

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -92,7 +92,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.0"
+$script:AppVersion = "1.3.1"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -19,7 +19,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.0"
+$script:AppVersion = "1.3.1"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/setup_utils.ps1
+++ b/scripts/setup_utils.ps1
@@ -61,11 +61,18 @@ function Replace-PasswordWithPlaceholder {
             if ($fileSize -eq 0) { $fileSize = 64 }  # Minimum overwrite size
 
             # Overwrite with random data (3 passes for security)
-            for ($pass = 1; $pass -le 3; $pass++) {
-                $randomBytes = New-Object byte[] $fileSize
-                [System.Security.Cryptography.RandomNumberGenerator]::Fill($randomBytes)
-                [System.IO.File]::WriteAllBytes($passwordFile, $randomBytes)
-                Write-Host "[SECURITY] Overwrite pass $pass complete" -ForegroundColor DarkGray
+            # Use Create()/GetBytes() rather than the static Fill() - Fill() only exists in
+            # .NET Core 2.1+ (PowerShell 7), not in Windows PowerShell 5.1 (.NET Framework)
+            $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+            try {
+                for ($pass = 1; $pass -le 3; $pass++) {
+                    $randomBytes = New-Object byte[] $fileSize
+                    $rng.GetBytes($randomBytes)
+                    [System.IO.File]::WriteAllBytes($passwordFile, $randomBytes)
+                    Write-Host "[SECURITY] Overwrite pass $pass complete" -ForegroundColor DarkGray
+                }
+            } finally {
+                $rng.Dispose()
             }
 
             # Replace with placeholder instead of deleting

--- a/scripts/setup_wizard.ps1
+++ b/scripts/setup_wizard.ps1
@@ -1697,12 +1697,12 @@ $btnNext.Add_Click({
             # AI CLI tools will be auto-installed by entrypoint.sh
             $status.Text = 'Installing AI CLI tools suite...'
             Write-Host "[INFO] Container is auto-installing AI CLI tools..." -ForegroundColor Cyan
-            Write-Host "[INFO] Installing: Claude, GitHub CLI, Gemini, OpenAI SDK, Codex..." -ForegroundColor Yellow
-            Write-Host "[INFO] This will take 3-5 minutes on first run..." -ForegroundColor Yellow
+            Write-Host "[INFO] Installing: Claude, GitHub CLI, Gemini, OpenAI SDK, Codex, Vibe Kanban, 9router, OmniRoute..." -ForegroundColor Yellow
+            Write-Host "[INFO] This will take 5-10 minutes on first run..." -ForegroundColor Yellow
             Write-Host "[INFO] This step requires internet connection" -ForegroundColor Yellow
 
             # Wait for the entrypoint to run the installation
-            $status.Text = 'Waiting for CLI tools installation (3-5 minutes)...'
+            $status.Text = 'Waiting for CLI tools installation (5-10 minutes)...'
 
             # Initialize terminal display
             $script:terminalBox.Text = ">> Installation starting...`r`n"
@@ -1758,7 +1758,9 @@ $btnNext.Add_Click({
             }
 
             # Check installation progress by looking for the marker file
-            $maxWaitTime = 300  # 5 minutes
+            # 8 tools install sequentially (gh, Claude, Gemini, OpenAI SDK, Codex, Vibe Kanban,
+            # 9router, OmniRoute) - 5 minutes was routinely exceeded after the routers were added
+            $maxWaitTime = 600  # 10 minutes
             $waitedTime = 0
             $checkInterval = 3  # Check more frequently for better UI updates
 
@@ -1793,13 +1795,17 @@ $btnNext.Add_Click({
                         $script:lblCurrentTool.Text = "Installing $toolName via $pkgMgr..."
                         Write-Host "[STATUS] Installing: $toolName ($pkgMgr)" -ForegroundColor Cyan
 
-                        # Update progress based on which tool is currently installing (5 tools total)
+                        # Update progress based on which tool is currently installing (8 tools total)
+                        # Names must match update_install_status calls in docker/install_cli_tools.sh
                         $toolProgress = switch ($toolName) {
-                            'GitHub CLI' { 20 }
-                            'Claude Code CLI' { 40 }
-                            'Google Gemini CLI' { 60 }
-                            'OpenAI Python SDK' { 80 }
-                            'OpenAI Codex CLI' { 95 }
+                            'GitHub CLI' { 15 }
+                            'Claude Code CLI' { 30 }
+                            'Google Gemini CLI' { 45 }
+                            'OpenAI Python SDK' { 55 }
+                            'OpenAI Codex CLI' { 65 }
+                            'Vibe Kanban' { 80 }
+                            '9router' { 90 }
+                            'OmniRoute' { 95 }
                             default { $progress.Value }  # Keep current if unknown
                         }
                         $progress.Value = $toolProgress
@@ -1819,6 +1825,9 @@ $btnNext.Add_Click({
 
             if ($waitedTime -ge $maxWaitTime) {
                 Write-Host "[WARNING] Installation is taking longer than expected, but will continue in background" -ForegroundColor Yellow
+                Write-Host "[INFO] This is not an error - the container keeps installing after this window closes" -ForegroundColor Cyan
+                Write-Host "[INFO] Watch progress with: docker logs -f ai-cli" -ForegroundColor Cyan
+                Write-Host "[INFO] Or check status inside the container: cat ~/.cli_tools_installed" -ForegroundColor Cyan
                 $script:terminalBox.AppendText("`r`n>> Installation taking longer than expected, continuing in background...`r`n")
             }
 
@@ -1833,7 +1842,8 @@ $btnNext.Add_Click({
             if ($r3a.Ok -and $r3a.StdOut -match 'Claude found') {
                 Write-Host "[SUCCESS] Claude CLI verified" -ForegroundColor Green
             } else {
-                Write-Host "[WARNING] Claude CLI not found yet, will be installed in background" -ForegroundColor Yellow
+                Write-Host "[WARNING] Claude CLI not found yet - it will finish installing in the background" -ForegroundColor Yellow
+                Write-Host "[INFO] Your shell will show an 'Installing...' spinner until it's ready" -ForegroundColor Cyan
             }
 
             # Test 2: Check if GitHub CLI exists


### PR DESCRIPTION
## Description

Fixes two issues introduced in the 1.3.0 rebuild:

1. **Wizard timeout during CLI tool installation**: After adding 9router and OmniRoute in 1.3.0, the container now installs 8 tools sequentially instead of 5, routinely exceeding the 5-minute wait timeout. The wizard now waits 10 minutes and provides clearer messaging that installation continues in the background (users see an "Installing..." spinner in their shell until completion).

2. **PowerShell 5.1 incompatibility in password cleanup**: The `RandomNumberGenerator::Fill()` method only exists in PowerShell 7 (.NET Core), not Windows PowerShell 5.1 (.NET Framework). Changed to use `Create()`/`GetBytes()` which works on both versions. The fallback path still replaced the password with a placeholder, so there was no security impact—just missing overwrite passes.

3. **Progress bar stalling**: Updated the wizard's progress tracking to include all 8 tools (was only tracking 5), so the progress bar no longer stalls at 95% while the new tools install.

### Changed
- Increased CLI tool installation timeout from 5 to 10 minutes
- Updated timeout/verification messages to clarify that installation continues in background
- Fixed `RandomNumberGenerator` usage for Windows PowerShell 5.1 compatibility
- Extended progress bar tracking to cover all 8 tools with updated percentages
- Added helpful diagnostic commands in timeout warning messages

### Version
- Bumped to 1.3.1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

## Testing Instructions

1. Run the setup wizard on a Windows PowerShell 5.1 system (or test the `Replace-PasswordWithPlaceholder` function directly)
2. Perform a Force Rebuild to trigger the full 8-tool installation sequence
3. Verify the progress bar updates through all 8 tools (15% → 30% → 45% → 55% → 65% → 80% → 90% → 95%)
4. Confirm the wizard waits the full 10 minutes before showing the timeout message
5. Verify timeout messages include the diagnostic commands for checking background progress

## Additional Notes

No container changes—this is purely a wizard fix. The container was installing correctly; the wizard just gave up waiting too early and had a PowerShell compatibility issue during cleanup.

https://claude.ai/code/session_016DbiWhWcPeZgWADYD9gYfb