### PR TITLE
fix: password-file ACL without elevation + suppress Ubuntu sudo hint (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-07-07
+
+### Fixed
+- **"Set-Acl: The process does not possess the 'SeSecurityPrivilege' privilege" error during password-file creation.** `Set-Acl` writes the owner/SACL sections of the security descriptor in addition to the permission list, which requires a privilege that non-elevated PowerShell sessions don't hold. The chmod-600-equivalent lockdown now uses `icacls /inheritance:r /grant:r`, which only modifies the permission list and works without elevation. Impact of the old bug was low: the file lives under the user profile (already restricted by inherited permissions) and is scrubbed to a placeholder after setup — but the hardening now actually applies.
+- **Misleading "[SECURITY] Password file permissions restricted" success message after the ACL step had just failed.** The `Set-Acl` error was non-terminating, so the failure handler never ran; the icacls exit code is now checked explicitly and failures report a warning instead of a false success.
+
 ## [1.3.1] - 2026-07-07
 
 Fixes the scary-but-harmless errors the setup wizard showed after rebuilding for 1.3.0. No container changes - the container itself was installing fine; the wizard just gave up waiting too early and hit a PowerShell 5.1 incompatibility during cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **"Set-Acl: The process does not possess the 'SeSecurityPrivilege' privilege" error during password-file creation.** `Set-Acl` writes the owner/SACL sections of the security descriptor in addition to the permission list, which requires a privilege that non-elevated PowerShell sessions don't hold. The chmod-600-equivalent lockdown now uses `icacls /inheritance:r /grant:r`, which only modifies the permission list and works without elevation. Impact of the old bug was low: the file lives under the user profile (already restricted by inherited permissions) and is scrubbed to a placeholder after setup — but the hardening now actually applies.
 - **Misleading "[SECURITY] Password file permissions restricted" success message after the ACL step had just failed.** The `Set-Acl` error was non-terminating, so the failure handler never ran; the icacls exit code is now checked explicitly and failures report a warning instead of a false success.
+- **Ubuntu's first-login sudo hint no longer appears in the wizard console.** The 'To run a command as administrator (user "root"), use "sudo <command>"' message is a stock Ubuntu hint printed on a sudo-group user's first login, and every rebuild re-triggered it (fresh home directory = missing `~/.sudo_as_admin_successful` flag). It was harmless but read like an error, so the entrypoint now pre-creates the flag file. Requires a container rebuild to take effect.
 
 ## [1.3.1] - 2026-07-07
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -346,6 +346,14 @@ else
   fi
 fi
 
+# Suppress Ubuntu's first-login sudo hint ('To run a command as administrator (user "root"),
+# use "sudo <command>". See "man sudo_root" for details.'). /etc/bash.bashrc prints it whenever
+# a sudo-group user logs in and ~/.sudo_as_admin_successful doesn't exist - which is every
+# rebuild, since the home directory is recreated. Harmless, but it reads like an error in the
+# wizard console, so pre-create the flag file.
+touch "/home/$USER_NAME/.sudo_as_admin_successful"
+chown "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.sudo_as_admin_successful"
+
 # Install CLI tools on first run (runs as the user)
 # If FORCE_CLI_REINSTALL is set, force reinstallation even if marker file exists
 entrypoint_log "INFO" "Checking CLI tools installation..."

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -92,7 +92,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.1"
+$script:AppVersion = "1.3.2"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -19,7 +19,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.1"
+$script:AppVersion = "1.3.2"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/setup_utils.ps1
+++ b/scripts/setup_utils.ps1
@@ -192,20 +192,21 @@ function New-SecurePasswordFile {
     [System.IO.File]::WriteAllText($passwordFile, $Password, $utf8NoBom)
 
     # Set restrictive permissions (Windows equivalent of chmod 600)
-    try {
-        $acl = Get-Acl $passwordFile
-        $acl.SetAccessRuleProtection($true, $false)  # Disable inheritance
-        $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-            $currentUser,
-            "FullControl",
-            "Allow"
-        )
-        $acl.SetAccessRule($rule)
-        Set-Acl -Path $passwordFile -AclObject $acl
-        Write-Host "[SECURITY] Password file permissions restricted" -ForegroundColor Green
-    } catch {
-        Write-Host "[WARNING] Could not set restrictive permissions: $($_.Exception.Message)" -ForegroundColor Yellow
+    # Use icacls rather than Set-Acl: Set-Acl also writes the owner/SACL sections of the
+    # security descriptor, which requires SeSecurityPrivilege and fails ("does not possess
+    # the 'SeSecurityPrivilege' privilege") in a normal non-elevated PowerShell session.
+    # icacls only touches the DACL, which the file owner can always modify.
+    if ($env:OS -eq 'Windows_NT') {
+        try {
+            $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+            $icaclsOutput = & icacls.exe $passwordFile /inheritance:r /grant:r "${currentUser}:F" 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "icacls exited with code ${LASTEXITCODE}: $icaclsOutput"
+            }
+            Write-Host "[SECURITY] Password file permissions restricted" -ForegroundColor Green
+        } catch {
+            Write-Host "[WARNING] Could not set restrictive permissions: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
     }
 
     Write-Host "[SECURITY] Password file created at: $passwordFile" -ForegroundColor Green


### PR DESCRIPTION
## Description

Two cosmetic-but-alarming errors reported from wizard console output during v1.3.1 rebuilds.

**1. `Set-Acl : The process does not possess the 'SeSecurityPrivilege' privilege` during password-file creation** (`scripts/setup_utils.ps1`):

- **`Set-Acl` needs elevation it doesn't have.** `Set-Acl` writes the owner/SACL sections of the security descriptor in addition to the permission list, which requires `SeSecurityPrivilege` — a privilege normal non-elevated PowerShell sessions don't hold. The chmod-600-equivalent lockdown now uses `icacls /inheritance:r /grant:r`, which only modifies the DACL (always writable by the file owner) and works in both Windows PowerShell 5.1 and PowerShell 7.
- **False success message.** The `Set-Acl` error was non-terminating, so the `catch` block never ran and the wizard printed `[SECURITY] Password file permissions restricted` right after the visible failure. The icacls exit code is now checked explicitly, so failures surface as the intended `[WARNING]` instead.
- The ACL step is skipped on non-Windows (`$env:OS -ne 'Windows_NT'`) since the Pester suite also runs on Linux CI where `icacls` doesn't exist.
- Impact of the old bug was low — the file lives under the user profile (already restricted by inherited permissions) and is scrubbed to a placeholder after setup — but the hardening now actually applies.

**2. Ubuntu's first-login sudo hint appearing in the wizard console** (`docker/entrypoint.sh`):

- `To run a command as administrator (user "root"), use "sudo <command>"` is a stock Ubuntu hint that `/etc/bash.bashrc` prints when a sudo-group user logs in without `~/.sudo_as_admin_successful` present — which is every rebuild, since the home directory is recreated. Harmless, but it reads like an error. The entrypoint now pre-creates the flag file. This part requires a container rebuild to take effect.

Also bumps the version 1.3.1 → 1.3.2 and adds CHANGELOG entries.

## Related Issue

N/A — reported by the user from wizard console output during v1.3.1 rebuilds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have tested my changes locally
- [x] I have updated the documentation (if applicable)
- [x] I have added/updated tests (if applicable) — existing Pester test `Sets restrictive ACL permissions` (asserts `AreAccessRulesProtected`) covers the new icacls path; no new tests needed
- [x] My code follows the project's coding style
- [x] I have checked that there are no merge conflicts

## Screenshots (if applicable)

N/A (console-only change)

## Testing Instructions

1. On Windows, in a **non-elevated** PowerShell session, dot-source `scripts/setup_utils.ps1` and run `New-SecurePasswordFile -Password 'test' -DockerPath $env:TEMP`.
2. Confirm no `Set-Acl`/`SeSecurityPrivilege` error appears and `[SECURITY] Password file permissions restricted` is printed.
3. Run `icacls $env:TEMP\.secrets\password.txt` — it should show only your user with full control and no inherited entries (`Get-Acl` shows `AreAccessRulesProtected = True`).
4. For the sudo hint: Force Rebuild the container with this branch's `entrypoint.sh`, open a shell (`docker exec -it ai-cli bash` or via the launcher) — the "To run a command as administrator..." message no longer appears on first login.
5. CI: the `Sets restrictive ACL permissions` Pester test exercises the same assertion on the Windows runner.

## Additional Notes

Follow-up to #60 (merged, released as v1.3.1). The branch was restarted from the latest `main`, so this PR contains only these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DbiWhWcPeZgWADYD9gYfb