### PR TITLE
fix: stop blocking container startup on recursive workspace chown (v1.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-07-07
+
+Fixes the root cause of CLI tools never finishing installation after a rebuild. Force Rebuild required to pick up the new entrypoint.
+
+### Fixed
+- **Container startup stalled for 15+ minutes on "Setting ownership of /workspace", so the CLI tools installer never ran** (no `claude`/`gh` after rebuild, no install status, no login spinner, and the Ubuntu sudo hint appeared because `.bashrc` was never written — everything downstream of the stall). `/workspace` is a bind mount of a Windows folder, where every file operation is a slow Windows↔WSL round trip and ownership is dictated by Docker's mount options rather than per-file inodes, so the blocking recursive `chown` was both extremely slow on large workspaces and pointless. The entrypoint now chowns only the mount point synchronously, skips the recursive pass when chown has no effect (Windows-backed mount), and otherwise runs it in the background — startup can no longer block on workspace size. Workspace files are never modified by any of this; only ownership metadata.
+- **Workaround for containers built with older images:** if a rebuild appears stuck installing tools, run `docker exec ai-cli pkill -f "chown -R"` — the entrypoint logs a warning and proceeds with installation.
+
 ## [1.3.2] - 2026-07-07
 
 ### Fixed

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -110,10 +110,24 @@ fi
 unset USER_PASSWORD
 cleanup_credentials
 
-# Give user ownership of workspace
+# Give user ownership of workspace.
+# /workspace is typically a bind mount of a Windows folder (e.g. C:\AI_Work), where every file
+# operation is a Windows<->WSL round trip and ownership is dictated by Docker's mount options,
+# not per-file inodes. A blocking recursive chown over a large workspace stalled here for 15+
+# minutes, and the CLI tools installer (which runs later in this script) never started. So:
+# chown the mount point synchronously, skip the recursion when chown has no effect (Windows-
+# backed mount), and otherwise run it in the background so startup never blocks on it.
 entrypoint_log "INFO" "Setting ownership of /workspace to $USER_NAME"
-if ! chown -R "$USER_NAME:$USER_NAME" /workspace 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
+if ! chown "$USER_NAME:$USER_NAME" /workspace 2>&1 | tee -a "${LOG_FILE:-/dev/null}"; then
     entrypoint_log "WARN" "Could not change ownership of /workspace (may not exist or permission denied)"
+elif [ "$(stat -c %U /workspace 2>/dev/null)" != "$USER_NAME" ]; then
+    entrypoint_log "INFO" "/workspace ownership is controlled by the host mount - skipping recursive chown"
+else
+    (
+        chown -R "$USER_NAME:$USER_NAME" /workspace 2>/dev/null || true
+        entrypoint_log "INFO" "Background recursive chown of /workspace finished"
+    ) &
+    entrypoint_log "INFO" "Recursive chown of /workspace continuing in background"
 fi
 
 # CRITICAL: Ensure user's home directory has correct ownership

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -92,7 +92,7 @@ Write-AppLog "Files directory: $filesDir" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.2"
+$script:AppVersion = "1.3.3"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 

--- a/scripts/AI_Docker_Launcher.ps1
+++ b/scripts/AI_Docker_Launcher.ps1
@@ -19,7 +19,7 @@ Write-AppLog "========================================" "INFO"
 # ============================================================
 # CONFIGURATION - Edit these values if forking/moving the repo
 # ============================================================
-$script:AppVersion = "1.3.2"
+$script:AppVersion = "1.3.3"
 $script:GitHubRepo = "Cainmani/ai-docker-sandbox"
 $script:DockerDesktopPath = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 


### PR DESCRIPTION
## Description

Root-cause fix for CLI tools never finishing installation after a rebuild — the actual bug behind the symptoms patched cosmetically in v1.3.1/v1.3.2.

**Diagnosis** (from a real user container): `docker logs ai-cli` showed the entrypoint stopping dead at `Setting ownership of /workspace` on two consecutive container starts, 15+ minutes each. Everything downstream of that line never ran:

- the CLI tools installer → no `claude`/`gh`, empty `.cli_install_status`, wizard timeout
- the `.bashrc` setup → no "Installing..." login spinner, and Ubuntu's sudo hint appeared (the flag file that suppresses it is created after this point)

**Root cause:** `/workspace` is a bind mount of a Windows folder (e.g. `C:\AI_Work`). On those mounts every file operation is a slow Windows↔WSL round trip, and ownership is dictated by Docker's mount options rather than per-file inodes — so the blocking `chown -R` was both extremely slow (scales with workspace size) and pointless.

**Fix** (`docker/entrypoint.sh`): chown only the mount point synchronously, then:
- if the chown had no effect (Windows-backed mount where the host controls ownership), skip the recursive pass entirely;
- otherwise (native Linux volume) run the recursive pass in the background.

Startup can no longer block on workspace size. No file contents are ever touched — chown only changes ownership metadata.

Also bumps the version 1.3.2 → 1.3.3 and adds a CHANGELOG entry, including a workaround for containers still on older images: `docker exec ai-cli pkill -f "chown -R"` unsticks the entrypoint (the chown failure is already handled as a warning) and installation proceeds.

## Related Issue

N/A — diagnosed from user-supplied `docker logs ai-cli` output after v1.3.1/v1.3.2 rebuilds repeatedly ended with no CLI tools installed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [ ] I have tested my changes locally
- [x] I have updated the documentation (if applicable)
- [ ] I have added/updated tests (if applicable)
- [x] My code follows the project's coding style
- [x] I have checked that there are no merge conflicts

## Screenshots (if applicable)

N/A

## Testing Instructions

1. With a large workspace folder (many files) configured as `C:\AI_Work`, run setup with **Force Rebuild** so the image picks up the new entrypoint.
2. `docker logs -f ai-cli` — the log should pass `Setting ownership of /workspace` within seconds (logging either "skipping recursive chown" on Windows-backed mounts or "continuing in background"), and proceed straight to CLI tool installation.
3. Confirm the wizard's install phase completes within its window and `docker exec ai-cli bash -lc "which claude gh"` succeeds afterwards.
4. Sanity: `bash -n docker/entrypoint.sh` passes (verified).

## Additional Notes

Follow-up to #61 (merged, released as v1.3.2). Branch restarted from the latest `main`; this PR contains only this fix. Requires a Force Rebuild after release since `entrypoint.sh` is baked into the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016DbiWhWcPeZgWADYD9gYfb

---
_Generated by [Claude Code](https://claude.ai/code/session_016DbiWhWcPeZgWADYD9gYfb)_