### PR TITLE
Fix update-container-tools uninstalling tools on failed npm update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2026-07-10
+
+Fixes `update-container-tools` being able to uninstall a tool it was supposed to update. No rebuild strictly required — the fix takes effect the next time the container picks up the new `auto_update.sh` (Force Rebuild, or `docker compose up -d --force-recreate`).
+
+### Fixed
+- **`update-container-tools --force` could leave a tool uninstalled** (`command not found` afterwards, e.g. OmniRoute). `npm update -g` removes a package before installing the new version, so a mid-update failure (network error, peer-dependency conflict, native build failure) deleted the tool instead of updating it. The updater now snapshots the installed global npm packages before updating and automatically reinstalls (with retries and cache-clean between attempts) anything the update removed.
+- If you were already hit by this: restore the missing tool with `npm install -g <package>` (e.g. `npm install -g omniroute`). Note the `-g` — a plain `npm install omniroute` installs into the current directory instead of restoring the command.
+
 ## [1.3.4] - 2026-07-07
 
 Fixes switching between the two AI routers. Force Rebuild (or `docker compose up -d --force-recreate`) recommended so the container regenerates the updated `~/.bashrc` router wrappers.

--- a/docker/auto_update.sh
+++ b/docker/auto_update.sh
@@ -139,6 +139,15 @@ apply_updates() {
     # Update ALL global npm packages (dynamic)
     # Note: Claude Code is no longer installed via npm (uses native installer)
     update_log "Updating npm packages..."
+
+    # Snapshot the installed global packages BEFORE updating. "npm update -g"
+    # removes a package before reinstalling the new version, so a mid-update
+    # failure (network error, peer-dependency conflict, native build failure)
+    # can leave a tool uninstalled entirely rather than just out of date.
+    # Anything that disappears during the update gets reinstalled below.
+    # The sed keeps scoped names intact (e.g. @google/gemini-cli).
+    npm_packages_before=$(npm ls -g --depth=0 --parseable 2>/dev/null | tail -n +2 | sed 's|^.*/node_modules/||' || true)
+
     npm_output=$(npm update -g 2>&1)
     npm_exit_code=$?
     if [ $npm_exit_code -eq 0 ]; then
@@ -150,6 +159,32 @@ apply_updates() {
         update_log "${RED}[ERROR]${NC} npm update failed (exit code: $npm_exit_code)"
         echo "$npm_output" | while read line; do update_log "  $line"; done
     fi
+
+    # Reinstall any global package that the update removed instead of updating
+    npm_packages_after=$(npm ls -g --depth=0 --parseable 2>/dev/null | tail -n +2 | sed 's|^.*/node_modules/||' || true)
+    while IFS= read -r pkg; do
+        [ -n "$pkg" ] || continue
+        if ! printf '%s\n' "$npm_packages_after" | grep -qxF "$pkg"; then
+            update_log "${YELLOW}[WARNING]${NC} $pkg was removed by a failed update - reinstalling..."
+            reinstalled=0
+            for reinstall_attempt in 1 2 3; do
+                reinstall_output=$(npm install -g "$pkg" 2>&1)
+                if [ $? -eq 0 ]; then
+                    reinstalled=1
+                    break
+                fi
+                update_log "  Reinstall attempt $reinstall_attempt/3 failed for $pkg"
+                npm cache clean --force 2>/dev/null || true
+                sleep 3
+            done
+            if [ $reinstalled -eq 1 ]; then
+                update_log "${GREEN}[SUCCESS]${NC} Reinstalled $pkg"
+            else
+                update_log "${RED}[ERROR]${NC} Could not reinstall $pkg - install manually with: npm install -g $pkg"
+                echo "$reinstall_output" | tail -n 20 | while read line; do update_log "  $line"; done
+            fi
+        fi
+    done <<< "$npm_packages_before"
 
     # Update ALL user pip packages (dynamic)
     update_log "Updating Python packages..."


### PR DESCRIPTION
## Problem

Running `update-container-tools --force` could leave a CLI tool uninstalled entirely — the reported case was OmniRoute disappearing (`bash: omniroute: command not found`) after an update.

`auto_update.sh` runs a blanket `npm update -g`, and npm removes a package before installing its new version. If the update fails partway (network error, peer-dependency conflict, native build failure — OmniRoute's large dependency tree with React peer-dep conflicts makes this likely), the old version is already gone and nothing replaces it. The updater logged an error but left the tool missing.

## Fix

`docker/auto_update.sh` now:
- Snapshots the installed global npm packages (via `npm ls -g --depth=0 --parseable`, preserving scoped names like `@google/gemini-cli`) before running `npm update -g`.
- After the update, reinstalls any package that disappeared — up to 3 attempts with `npm cache clean --force` between retries.
- If all retries fail, logs the exact `npm install -g <package>` command for manual recovery instead of failing silently.

Also adds a `1.3.5` CHANGELOG entry documenting the bug and the manual recovery step for users already affected.

## Testing

- `bash -n` syntax check passes.
- The before/after diff logic was exercised in isolation with simulated package lists: it correctly flags only the removed package and handles scoped package names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Zj4bS49FZMKWKcywr2XXY

---
_Generated by [Claude Code](https://claude.ai/code/session_018Zj4bS49FZMKWKcywr2XXY)_