### PR TITLE
fix(launcher): execution policy errors; versioned EXE; router hardening + CLI routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,11 @@ jobs:
       - name: Verify build
         shell: pwsh
         run: |
-          $outputPath = Join-Path $PWD "AI_Docker_Manager.exe"
+          $versionedName = "AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe"
+          $outputPath = Join-Path $PWD $versionedName
 
           if (-not (Test-Path $outputPath)) {
-            Write-Error "Build failed - output file not found"
+            Write-Error "Build failed - output file $versionedName not found"
             exit 1
           }
 
@@ -82,12 +83,18 @@ jobs:
           Write-Host "Build successful: $outputPath (file version $actualVersion)"
           Get-Item $outputPath | Select-Object Name, Length, LastWriteTime
 
-      - name: Generate SHA256 checksum
+          # Also publish a stable-named copy so the permanent
+          # releases/latest/download/AI_Docker_Manager.exe link keeps working.
+          Copy-Item $outputPath (Join-Path $PWD "AI_Docker_Manager.exe") -Force
+
+      - name: Generate SHA256 checksums
         id: checksum
         shell: pwsh
         run: |
-          $hash = (Get-FileHash -Path "AI_Docker_Manager.exe" -Algorithm SHA256).Hash
+          $versionedName = "AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe"
+          $hash = (Get-FileHash -Path $versionedName -Algorithm SHA256).Hash
           echo "SHA256=$hash" >> $env:GITHUB_OUTPUT
+          echo "$hash  $versionedName" | Out-File -FilePath "$versionedName.sha256" -Encoding utf8
           echo "$hash  AI_Docker_Manager.exe" | Out-File -FilePath "AI_Docker_Manager.exe.sha256" -Encoding utf8
           Write-Host "SHA256: $hash"
 
@@ -95,6 +102,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: |
+            AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe
+            AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe.sha256
             AI_Docker_Manager.exe
             AI_Docker_Manager.exe.sha256
           body: |
@@ -102,7 +111,7 @@ jobs:
 
             ### Installation
 
-            1. Download `AI_Docker_Manager.exe` below
+            1. Download `AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe` below (or `AI_Docker_Manager.exe` — same file, stable name)
             2. Run the executable (you may need to click "More info" → "Run anyway" on Windows SmartScreen)
             3. Click "First Time Setup" to begin
 

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -743,8 +743,11 @@ $btnLaunch.Add_Click({
         if ($dockerHelpersContent -and $logUtilsContent) {
             [System.IO.File]::WriteAllText((Join-Path $filesDir 'docker_helpers.ps1'), $dockerHelpersContent, [System.Text.UTF8Encoding]::new($false))
             [System.IO.File]::WriteAllText((Join-Path $filesDir 'log_utils.ps1'), $logUtilsContent, [System.Text.UTF8Encoding]::new($false))
-            . (Join-Path $filesDir 'log_utils.ps1')
-            . (Join-Path $filesDir 'docker_helpers.ps1')
+            # Load in-process from embedded content, not the extracted files:
+            # dot-sourcing a .ps1 from disk is subject to the machine's execution
+            # policy (Restricted by default), which the compiled EXE inherits.
+            . ([ScriptBlock]::Create($logUtilsContent))
+            . ([ScriptBlock]::Create($dockerHelpersContent))
             $versionSkew = Test-ContainerVersionSkew -LauncherVersion $script:AppVersion
             if ($versionSkew.SkewDetected) {
                 $containerVersionText = if ($versionSkew.ContainerVersion) { "v$($versionSkew.ContainerVersion)" } else { 'a legacy version' }
@@ -975,9 +978,23 @@ function Test-DockerRunning {
         }
     }
 
-    . $logUtils
-    . $dockerHelpers
-    return DockerOk -TimeoutSeconds 30
+    # Load in-process from embedded content, not the extracted files:
+    # dot-sourcing a .ps1 from disk is subject to the machine's execution
+    # policy (Restricted by default), which the compiled EXE inherits. The
+    # files above are still extracted for the child launch scripts, which
+    # run with -ExecutionPolicy Bypass.
+    foreach ($helperName in @('log_utils.ps1', 'docker_helpers.ps1')) {
+        $helperContent = Get-EmbeddedFileContent $helperName
+        if ($helperContent) {
+            . ([ScriptBlock]::Create($helperContent))
+        }
+    }
+    if (Get-Command DockerOk -ErrorAction SilentlyContinue) {
+        return DockerOk -TimeoutSeconds 30
+    }
+    Write-AppLog "Docker helpers unavailable in embedded resources - falling back to direct docker check" "WARN"
+    docker info 2>$null | Out-Null
+    return ($LASTEXITCODE -eq 0)
 }
 
 $dockerRunning = Test-DockerRunning

--- a/scripts/build/BUILD_NOW.bat
+++ b/scripts/build/BUILD_NOW.bat
@@ -14,6 +14,6 @@ echo ================================================================
 echo    BUILD COMPLETE!
 echo ================================================================
 echo.
-echo Check for AI_Docker_Manager.exe in this directory.
+echo Check for AI_Docker_Manager_v^<version^>.exe in the project root.
 echo.
 pause

--- a/scripts/build/build_complete_exe.ps1
+++ b/scripts/build/build_complete_exe.ps1
@@ -171,8 +171,9 @@ Write-Host "  OK Created AI_Docker_Complete_Bundled.ps1" -ForegroundColor Green
 # Compile to exe
 Write-Host "[3/4] Compiling to executable..." -ForegroundColor Cyan
 
-# Output to project root
-$exePath = Join-Path $projectRoot "AI_Docker_Manager.exe"
+# Output to project root, with the version in the file name
+$exeName = "AI_Docker_Manager_v$appVersion.exe"
+$exePath = Join-Path $projectRoot $exeName
 
 try {
     Invoke-ps2exe `
@@ -186,7 +187,7 @@ try {
         -noConsole
 
     if (Test-Path $exePath) {
-        Write-Host "  OK AI_Docker_Manager.exe created successfully!" -ForegroundColor Green
+        Write-Host "  OK $exeName created successfully!" -ForegroundColor Green
 
         $fileSize = (Get-Item $exePath).Length / 1MB
         Write-Host "  Size: $([math]::Round($fileSize, 2)) MB" -ForegroundColor Gray
@@ -219,7 +220,7 @@ Write-Host "  OK All shell scripts" -ForegroundColor Green
 Write-Host "  OK Complete documentation" -ForegroundColor Green
 Write-Host ""
 Write-Host "Users can:" -ForegroundColor Cyan
-Write-Host "  1. Download AI_Docker_Manager.exe" -ForegroundColor Yellow
+Write-Host "  1. Download $exeName" -ForegroundColor Yellow
 Write-Host "  2. Run it (extracts files on first run)" -ForegroundColor Yellow
 Write-Host "  3. Click First Time Setup to install" -ForegroundColor Yellow
 Write-Host "  4. Click Launch AI Workspace for terminal access" -ForegroundColor Yellow


### PR DESCRIPTION
## Description

Three groups of changes:

**1. Fix the 1.4.0 launcher startup errors on default execution policy.** The launcher EXE fails at startup on machines with the default `Restricted` PowerShell execution policy ("running scripts is disabled on this system", then "'DockerOk' is not recognized"). The EXE dot-sourced the extracted helper scripts from disk in its own process; helpers are now loaded in-process from the embedded content via `[ScriptBlock]::Create()`, which execution policy does not govern. The startup Docker check also falls back to a direct `docker info` call if the embedded helpers are unavailable.

**2. Versioned EXE file name.** `build_complete_exe.ps1` now outputs `AI_Docker_Manager_v<version>.exe` (from the `VERSION` file). The release workflow uploads the versioned executable plus a stable-named `AI_Docker_Manager.exe` copy (checksums for both) so the permanent `releases/latest/download/...` link in the README keeps working.

**3. AI router (9router/OmniRoute) hardening and actual CLI integration:**
- **CLI routing** — linking subscriptions in the router dashboard configures the *router*, but the container CLIs were never pointed at it. The `configure-tools` AI Router menu now offers to route the OpenAI-compatible CLIs (Codex, OpenAI SDK) and optionally Claude Code through the router: it writes the endpoint + router API key (from the dashboard) to `~/.router-data/cli-routing.env` (mode 600, persisted volume), sourced by the managed `~/.bashrc` block (bumped to v3). Disable any time from the same menu.
- **Loopback-only dashboards (security)** — the router and Vibe Kanban ports are now published as `127.0.0.1:20128` / `127.0.0.1:3000`. Previously Docker bound them to all host interfaces, exposing an unauthenticated dashboard holding linked AI provider credentials to the local network. Same-machine browser access unchanged; mobile access still goes through SSH.
- **Held version pins (security)** — the weekly blanket `npm update -g` walked the routers off their pinned versions. The installer now writes a pin manifest (`~/.npm-pinned-tools`) and `auto_update.sh` restores those exact versions after each run; router versions change only via a release that bumps the pins. Other tools update as before.
- **Real uninstall** — new AI Router menu option stops the routers, uninstalls both packages, and disables CLI routing so `claude`/`codex` talk directly to their providers again. An opt-out marker (persisted volume) stops container restarts/`--repair` from reinstalling them; dashboard data is kept unless explicitly deleted, and picking a router from the menu reinstalls it at the pinned version.

## Related Issue

Fixes the launcher startup errors reported after the 1.4.0 release (screenshots in the session; no tracked issue).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally (all bash suites: `test_bash_fixes` 38/38, `test_install_cli_tools` 16/16, `test_router_utils` 13/13, `test_auto_update` 12/12; two pre-existing environment-dependent failures in `test_entrypoint_helpers`/`test_configure_tools` reproduce identically on the unmodified tree. ShellCheck error-severity clean; compose + workflow YAML parse-checked. Pester tests are Windows-only and run in CI.)
- [x] I have updated the documentation (CHANGELOG `[Unreleased]` section)
- [ ] I have added/updated tests (if applicable)
- [x] My code follows the project's coding style
- [x] I have checked that there are no merge conflicts

## Screenshots (if applicable)

N/A — fixes the two startup error dialogs ("running scripts is disabled on this system" and "'DockerOk' is not recognized").

## Testing Instructions

1. On Windows with `Set-ExecutionPolicy Restricted -Scope CurrentUser`, rebuild via `scripts/build/build_complete_exe.ps1` — output is `AI_Docker_Manager_v<version>.exe` — and launch: no error popups; Docker detection and launch flows work.
2. Recreate the container (`docker compose up -d --force-recreate`): `Get-NetTCPConnection -LocalPort 20128` (or `netstat -ano | findstr 20128`) on the host should show the listener bound to `127.0.0.1`, not `0.0.0.0`.
3. In the container run `configure-tools` → AI Router: start a router, enable CLI routing with a key from the dashboard, open a new shell and confirm `echo $OPENAI_BASE_URL` points at `http://localhost:20128/v1`; then use the same menu to uninstall the routers and confirm the variable is gone in a new shell and the routers stay uninstalled after a container restart.
4. Run `update-container-tools` and confirm the log shows pinned router versions being held/restored.

## Additional Notes

A new EXE build and release is required for end users — the launcher bug is in the compiled EXE. A container Force Rebuild/recreate is needed for the loopback port binding and the v3 managed `~/.bashrc` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtDhHrArRUeuCCFBAjDMVW