### PR TITLE
ci: compiled-EXE smoke test under Restricted policy; docs: load-bearing invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,37 @@ jobs:
           $result = Invoke-Pester -Path tests -PassThru
           if ($result.FailedCount -gt 0) { exit 1 }
 
+  exe-smoke:
+    # Build the real EXE with ps2exe and launch it under the Windows DEFAULT
+    # (Restricted) execution policy. Every other suite tests the scripts; this
+    # is the only check that exercises the compiled artifact, catching bugs
+    # that exist only inside the ps2exe host (e.g. the v1.4.0 in-process
+    # dot-sourcing that the execution policy blocked).
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install ps2exe
+        shell: pwsh
+        run: |
+          Install-Module -Name ps2exe -RequiredVersion 1.0.17 -Force -Scope CurrentUser
+          Import-Module ps2exe
+
+      - name: Build executable
+        shell: pwsh
+        working-directory: scripts/build
+        run: |
+          & powershell.exe -ExecutionPolicy Bypass -File "build_complete_exe.ps1" -NonInteractive
+
+      - name: Smoke-test the EXE under Restricted execution policy
+        shell: pwsh
+        run: |
+          $version = (Get-Content VERSION -Raw).Trim()
+          $exePath = Join-Path $PWD "AI_Docker_Manager_v$version.exe"
+          & pwsh -NoProfile -File scripts/build/test_exe_smoke.ps1 -ExePath $exePath
+          if ($LASTEXITCODE -ne 0) { throw "EXE smoke test failed" }
+
   version-consistency:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,13 @@ jobs:
           # releases/latest/download/AI_Docker_Manager.exe link keeps working.
           Copy-Item $outputPath (Join-Path $PWD "AI_Docker_Manager.exe") -Force
 
+      - name: Smoke-test the EXE under Restricted execution policy
+        shell: pwsh
+        run: |
+          $versionedName = "AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe"
+          & pwsh -NoProfile -File scripts/build/test_exe_smoke.ps1 -ExePath (Join-Path $PWD $versionedName)
+          if ($LASTEXITCODE -ne 0) { throw "EXE smoke test failed - not releasing a broken launcher" }
+
       - name: Generate SHA256 checksums
         id: checksum
         shell: pwsh

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -75,6 +75,48 @@ All logging functions sanitize before writing to disk:
 
 ---
 
+## Load-Bearing Invariants
+
+Rules a change can silently break without any test failing locally. Read before touching the areas they name.
+
+### The EXE must run under a `Restricted` execution policy
+
+`AI_Docker_Complete.ps1` runs inside a ps2exe host on the end user's machine, where the Windows **default** execution policy blocks loading any `.ps1` file from disk. Therefore, inside the EXE's own process:
+
+- **Never dot-source an extracted `.ps1` file** (`. $path`). Load embedded content instead: `. ([ScriptBlock]::Create((Get-EmbeddedFileContent 'name.ps1')))`.
+- Child scripts are exempt — they are launched as separate processes with `-ExecutionPolicy Bypass` (keep that flag).
+- CI's `exe-smoke` job launches the built EXE under `Restricted` policy to enforce this (`scripts/build/test_exe_smoke.ps1`); the release workflow runs the same gate before publishing.
+
+### Runtime is Windows PowerShell 5.1, everywhere
+
+The EXE embeds a 5.1 host and every child process is `powershell.exe` (never `pwsh.exe`). No PS7-only syntax (`??`, ternary) or .NET Core-only APIs — the dual 5.1/7 Pester CI matrix exists to catch this.
+
+### Managed `~/.bashrc` block versioning
+
+`docker/lib/entrypoint_helpers.sh` regenerates a marked block in the container user's `.bashrc` on every start. **Any change to the block's content requires bumping `MANAGED_BLOCK_VERSION`**, or existing containers keep the old block forever (same version = no-op). User-authored content outside the markers must survive byte-for-byte.
+
+### Install marker semantics (`~/.cli_tools_installed`)
+
+`STATUS=ok|partial` is parsed by the entrypoint: `partial` triggers `install_cli_tools.sh --repair` on the next container start, which reinstalls anything unhealthy. Consequences:
+
+- A tool that is *deliberately* absent must be excluded from the marker's tool list, or repair will resurrect it. The AI router uninstall does this via the opt-out file `~/.router-data/routers-optout` — respect it in any new install/repair path.
+- Never write `STATUS=ok` while a required tool (`claude gh codex`) is broken.
+
+### npm version pins are literals, and the updater must not defeat them
+
+- CI's `check-pinned-versions` job **greps `install_cli_tools.sh` for literal `name@version` strings** (e.g. `9router@0.5.18`). Keep the pins as literals in that file even when refactoring into variables.
+- The weekly `auto_update.sh` runs a blanket `npm update -g`. Packages whose version must only change via a release (currently the credential-holding routers) are listed in the pin manifest `~/.npm-pinned-tools`, written by `install_cli_tools.sh` and re-applied by `auto_update.sh` after every update run. New "pinned forever" tools go in that manifest, not in ad-hoc updater logic.
+
+### Published ports bind to the host loopback interface only
+
+`docker-compose.yml` publishes the web dashboards as `127.0.0.1:<port>:<port>`. The router dashboard stores linked AI provider credentials and has no authentication — never publish it (or new web UIs) without the `127.0.0.1` prefix. Remote/mobile access goes through the SSH ports in `docker-compose.mobile.yml`, not through dashboard ports.
+
+### CLI routing contract
+
+`~/.router-data/cli-routing.env` (written by `configure_tools.sh`, mode 600) exports `OPENAI_BASE_URL`/`OPENAI_API_KEY` (and optionally the Anthropic equivalents) and is sourced by the managed `.bashrc` block. Absent file = routing disabled and CLIs talk to providers directly. Anything that creates or removes it must go through the AI Router menu's logic so enable/disable stays symmetric.
+
+---
+
 ## Build System
 
 ### Adding a New File to the .exe
@@ -169,8 +211,8 @@ Scripts are mounted read-only. Only for local development.
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Push/PR to main | PowerShell syntax check, Pester tests, Dockerfile validation, pinned version check |
-| `release.yml` | Push `v*.*.*` tag | Builds .exe on windows-latest, creates GitHub release with checksum |
+| `ci.yml` | Push/PR to main | PowerShell syntax check, Pester tests (5.1 + 7), bash suites, Dockerfile validation, pinned version check, **EXE smoke test** (builds the real EXE and launches it under a `Restricted` execution policy) |
+| `release.yml` | Push `v*.*.*` tag | Builds .exe on windows-latest, smoke-tests it under `Restricted` policy, creates GitHub release with checksums |
 
 ### Pester Tests
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,7 +75,9 @@ All bash suites run without Docker — they assert on script structure and use t
 
 ### CI
 
-`.github/workflows/ci.yml` runs on every push/PR to main: Linux PowerShell syntax/Pester, Windows PowerShell 5.1 and PowerShell 7 Pester, all bash suites, Dockerfile validation, blocking ShellCheck errors, visible nonblocking ShellCheck warnings, hadolint, release-version consistency, and pinned-version checks. `.github/workflows/docker-smoke.yml` uses uniquely named disposable resources for runtime build/readiness, migration, cron, router, mobile-override, and recreate-persistence checks.
+`.github/workflows/ci.yml` runs on every push/PR to main: Linux PowerShell syntax/Pester, Windows PowerShell 5.1 and PowerShell 7 Pester, all bash suites, Dockerfile validation, blocking ShellCheck errors, visible nonblocking ShellCheck warnings, hadolint, release-version consistency, pinned-version checks, and an **EXE smoke test** that builds the real executable with ps2exe and launches it under a `Restricted` execution policy (`scripts/build/test_exe_smoke.ps1` — the only check that exercises the compiled artifact rather than the scripts). `.github/workflows/docker-smoke.yml` uses uniquely named disposable resources for runtime build/readiness, migration, cron, router, mobile-override, and recreate-persistence checks.
+
+Before changing the managed `.bashrc` block, install markers, npm pins, published ports, or anything inside the EXE template, read **[CLAUDE.md → Load-Bearing Invariants](CLAUDE.md#load-bearing-invariants)** — those areas have rules that no local test enforces.
 
 ## Shell Scripts & Line Endings
 

--- a/scripts/build/test_exe_smoke.ps1
+++ b/scripts/build/test_exe_smoke.ps1
@@ -1,0 +1,131 @@
+# test_exe_smoke.ps1 - Launch the built EXE under a Restricted execution policy
+# and assert it survives startup (embedded helper loading + Docker check).
+#
+# This exists because the Pester/bash suites test the SCRIPTS, never the
+# compiled artifact: the v1.4.0 "running scripts is disabled on this system"
+# launcher bug shipped precisely because nothing ever ran the EXE on a machine
+# with the Windows default execution policy. Windows only.
+#
+# Success is defined by log markers that appear only AFTER Test-DockerRunning
+# has returned - i.e. after the embedded helper modules loaded and DockerOk
+# executed, the exact code path the execution-policy bug broke:
+#   - "Docker Desktop is not running"    (no Docker daemon: warning path)
+#   - "Performing startup update check"  (Docker present: fully past the check)
+#
+# Exit codes: 0 = startup marker reached, 1 = failure signature/crash/timeout.
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExePath,
+
+    [int]$TimeoutSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ExePath)) {
+    Write-Host "[FAIL] EXE not found: $ExePath" -ForegroundColor Red
+    exit 1
+}
+
+$logFile = Join-Path $env:LOCALAPPDATA 'AI-Docker-CLI\logs\ai-docker.log'
+
+$successPatterns = @(
+    'Docker Desktop is not running',
+    'Performing startup update check'
+)
+$failurePatterns = @(
+    'running scripts is disabled',
+    'is not recognized as the name of a cmdlet'
+)
+
+# The whole point of this test: the EXE must work under the Windows DEFAULT
+# policy. The EXE's ps2exe host reads the Windows PowerShell policy, so it is
+# set via powershell.exe (a pwsh-side Set-ExecutionPolicy would not apply).
+$previousPolicy = (& powershell.exe -NoProfile -Command 'Get-ExecutionPolicy -Scope CurrentUser').Trim()
+& powershell.exe -NoProfile -Command 'Set-ExecutionPolicy Restricted -Scope CurrentUser -Force' | Out-Null
+Write-Host "[INFO] CurrentUser Windows PowerShell execution policy set to Restricted (was: $previousPolicy)"
+
+if (Test-Path $logFile) { Remove-Item $logFile -Force }
+
+$process = $null
+$status = 'timeout'
+$matched = ''
+try {
+    Write-Host "[INFO] Launching $ExePath (timeout ${TimeoutSeconds}s)..."
+    $process = Start-Process -FilePath $ExePath -PassThru
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+
+        $log = ''
+        if (Test-Path $logFile) {
+            $log = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
+        }
+
+        if ($log) {
+            $failureHit = $failurePatterns | Where-Object { $log -match [regex]::Escape($_) } | Select-Object -First 1
+            if ($failureHit) {
+                $status = 'failure-signature'
+                $matched = $failureHit
+                break
+            }
+            $successHit = $successPatterns | Where-Object { $log -match [regex]::Escape($_) } | Select-Object -First 1
+            if ($successHit) {
+                $status = 'ok'
+                $matched = $successHit
+                break
+            }
+        }
+
+        # A GUI EXE that exits this early crashed (unhandled startup error).
+        # Grace-read the log once more on the next loop before concluding.
+        if ($process.HasExited) {
+            Start-Sleep -Seconds 2
+            $log = if (Test-Path $logFile) { Get-Content $logFile -Raw -ErrorAction SilentlyContinue } else { '' }
+            $successHit = $successPatterns | Where-Object { $log -and ($log -match [regex]::Escape($_)) } | Select-Object -First 1
+            if ($successHit) {
+                $status = 'ok'
+                $matched = $successHit
+            } else {
+                $status = 'exited'
+            }
+            break
+        }
+    }
+} finally {
+    if ($process -and -not $process.HasExited) {
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    }
+    & powershell.exe -NoProfile -Command "Set-ExecutionPolicy $previousPolicy -Scope CurrentUser -Force" | Out-Null
+    Write-Host "[INFO] CurrentUser execution policy restored to $previousPolicy"
+}
+
+Write-Host ''
+Write-Host '--- startup log ---'
+if (Test-Path $logFile) {
+    Get-Content $logFile -ErrorAction SilentlyContinue | Select-Object -Last 40 | ForEach-Object { Write-Host "  $_" }
+} else {
+    Write-Host '  (no log file was created)'
+}
+Write-Host '-------------------'
+Write-Host ''
+
+switch ($status) {
+    'ok' {
+        Write-Host "[PASS] EXE started under Restricted policy and reached startup marker: '$matched'" -ForegroundColor Green
+        exit 0
+    }
+    'failure-signature' {
+        Write-Host "[FAIL] Startup log contains failure signature: '$matched'" -ForegroundColor Red
+        exit 1
+    }
+    'exited' {
+        Write-Host '[FAIL] EXE exited during startup before reaching a success marker (crash?)' -ForegroundColor Red
+        exit 1
+    }
+    default {
+        Write-Host "[FAIL] No startup marker within ${TimeoutSeconds}s - the EXE is stuck or startup broke silently" -ForegroundColor Red
+        exit 1
+    }
+}


### PR DESCRIPTION
## Description

Items 2 and 6 from the A+ roadmap. Stacked on #67 (based on its branch so the diff shows only this work; GitHub will retarget to `main` when #67 merges and its branch is deleted).

**EXE smoke test — CI now tests the artifact, not just the scripts.** New `scripts/build/test_exe_smoke.ps1` sets the CurrentUser Windows PowerShell execution policy to `Restricted` (the Windows default), launches the built EXE, and asserts the startup log reaches a marker that only appears *after* the embedded helper modules loaded and the Docker check ran — the exact code path the v1.4.0 "running scripts is disabled" bug broke. It fails on the known failure signatures, an early process exit (crash), or a timeout, dumps the log tail either way, and restores the previous policy. Wired in twice:
- `ci.yml`: new `exe-smoke` job on `windows-latest` — builds the real EXE with ps2exe (pinned 1.0.17, same as release) on every push/PR and smoke-tests it.
- `release.yml`: same smoke test as a gate between the build-verify step and publishing the release.

**Load-bearing invariants documented.** New `docs/CLAUDE.md → Load-Bearing Invariants` section covering the rules a change can silently break with no local test failing: no in-process dot-sourcing inside the EXE (embedded `[ScriptBlock]::Create()` only), PowerShell 5.1-only runtime, the `MANAGED_BLOCK_VERSION` bump rule, install-marker `ok`/`partial` semantics and the router opt-out file, literal `name@version` pins (CI greps them) plus the `~/.npm-pinned-tools` manifest contract, loopback-only published ports, and the `cli-routing.env` contract. `DEVELOPMENT.md` points to it and its CI description now includes the smoke test.

## Related Issue

Follow-up to #67; addresses two items from the quality review discussed in-session.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally (workflow YAML parse-checked; `test_bash_fixes.sh` 38/38; the smoke script itself is Windows-only and will run in this PR's own CI via the new `exe-smoke` job)
- [x] I have updated the documentation (CLAUDE.md invariants section, DEVELOPMENT.md CI description)
- [x] I have added/updated tests (the EXE smoke test)
- [x] My code follows the project's coding style
- [x] I have checked that there are no merge conflicts

## Screenshots (if applicable)

N/A — CI and documentation.

## Testing Instructions

1. This PR's own CI run is the primary test: the `exe-smoke` job should build the EXE and pass the smoke test.
2. To verify it catches the bug class it was built for: check out `v1.4.0`'s `AI_Docker_Complete.ps1` helper-loading code (the `. $logUtils` dot-sourcing), rebuild, and run `pwsh scripts/build/test_exe_smoke.ps1 -ExePath <exe>` on a Windows machine — it should fail with the "running scripts is disabled" signature.
3. Locally on Windows: build via `scripts/build/build_complete_exe.ps1`, then run the smoke script against the produced `AI_Docker_Manager_v<version>.exe`.

## Additional Notes

The smoke test treats "Docker Desktop is not running" as success — it proves `Test-DockerRunning` returned, which requires the embedded helpers to have loaded. On runners where Docker is available it instead reaches the "Performing startup update check" marker. No CHANGELOG entry since this is CI/docs-only with no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtDhHrArRUeuCCFBAjDMVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtDhHrArRUeuCCFBAjDMVW)_