### PR TITLE
feat: self-update, OpenCode CLI, EXE smoke test, build embed validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
           gemini_ver=$(grep -oP '@google/gemini-cli@\K[0-9.]+' "$SCRIPT" | head -1)
           codex_ver=$(grep -oP '@openai/codex@\K[0-9.]+' "$SCRIPT" | head -1)
           vibe_ver=$(grep -oP 'vibe-kanban@\K[0-9.]+' "$SCRIPT" | head -1)
+          opencode_ver=$(grep -oP 'opencode-ai@\K[0-9.]+' "$SCRIPT" | head -1)
           ninerouter_ver=$(grep -oP '9router@\K[0-9.]+' "$SCRIPT" | head -1)
           omniroute_ver=$(grep -oP 'omniroute@\K[0-9.]+' "$SCRIPT" | head -1)
           openai_ver=$(grep -oP 'openai==\K[0-9.]+' "$SCRIPT" | head -1)
@@ -339,6 +340,7 @@ jobs:
           echo "  @google/gemini-cli: ${gemini_ver:-NOT FOUND}"
           echo "  @openai/codex: ${codex_ver:-NOT FOUND}"
           echo "  vibe-kanban: ${vibe_ver:-NOT FOUND}"
+          echo "  opencode-ai: ${opencode_ver:-NOT FOUND}"
           echo "  9router: ${ninerouter_ver:-NOT FOUND}"
           echo "  omniroute: ${omniroute_ver:-NOT FOUND}"
           echo "  openai (pip): ${openai_ver:-NOT FOUND}"
@@ -348,6 +350,7 @@ jobs:
           [ -n "$gemini_ver" ] && check_npm "@google/gemini-cli" "$gemini_ver"
           [ -n "$codex_ver" ] && check_npm "@openai/codex" "$codex_ver"
           [ -n "$vibe_ver" ] && check_npm "vibe-kanban" "$vibe_ver"
+          [ -n "$opencode_ver" ] && check_npm "opencode-ai" "$opencode_ver"
           [ -n "$ninerouter_ver" ] && check_npm "9router" "$ninerouter_ver"
           [ -n "$omniroute_ver" ] && check_npm "omniroute" "$omniroute_ver"
           [ -n "$openai_ver" ] && check_pip "openai" "$openai_ver"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,37 @@ jobs:
           $result = Invoke-Pester -Path tests -PassThru
           if ($result.FailedCount -gt 0) { exit 1 }
 
+  exe-smoke:
+    # Build the real EXE with ps2exe and launch it under the Windows DEFAULT
+    # (Restricted) execution policy. Every other suite tests the scripts; this
+    # is the only check that exercises the compiled artifact, catching bugs
+    # that exist only inside the ps2exe host (e.g. the v1.4.0 in-process
+    # dot-sourcing that the execution policy blocked).
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install ps2exe
+        shell: pwsh
+        run: |
+          Install-Module -Name ps2exe -RequiredVersion 1.0.17 -Force -Scope CurrentUser
+          Import-Module ps2exe
+
+      - name: Build executable
+        shell: pwsh
+        working-directory: scripts/build
+        run: |
+          & powershell.exe -ExecutionPolicy Bypass -File "build_complete_exe.ps1" -NonInteractive
+
+      - name: Smoke-test the EXE under Restricted execution policy
+        shell: pwsh
+        run: |
+          $version = (Get-Content VERSION -Raw).Trim()
+          $exePath = Join-Path $PWD "AI_Docker_Manager_v$version.exe"
+          & pwsh -NoProfile -File scripts/build/test_exe_smoke.ps1 -ExePath $exePath
+          if ($LASTEXITCODE -ne 0) { throw "EXE smoke test failed" }
+
   version-consistency:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,13 @@ jobs:
           # releases/latest/download/AI_Docker_Manager.exe link keeps working.
           Copy-Item $outputPath (Join-Path $PWD "AI_Docker_Manager.exe") -Force
 
+      - name: Smoke-test the EXE under Restricted execution policy
+        shell: pwsh
+        run: |
+          $versionedName = "AI_Docker_Manager_v${{ steps.get_version.outputs.VERSION }}.exe"
+          & pwsh -NoProfile -File scripts/build/test_exe_smoke.ps1 -ExePath (Join-Path $PWD $versionedName)
+          if ($LASTEXITCODE -ne 0) { throw "EXE smoke test failed - not releasing a broken launcher" }
+
       - name: Generate SHA256 checksums
         id: checksum
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **The launcher can now update itself.** When a new release is detected at startup, "Yes" downloads the new EXE, verifies its SHA256 against the release's published checksum, swaps the file in after the app exits, and relaunches automatically. An unverified or failed download changes nothing and falls back to the manual download page. ("No" still opens the download page; "Cancel" skips.)
+
+### Changed
+- **Build hardening:** `build_complete_exe.ps1` now round-trip-verifies every embedded file (the exact Base64 payload must be present in the bundled script), failing the build if a file is in the embed list but its placeholder is missing from the template — previously that shipped an EXE silently missing the file. The five copy-pasted helper-extraction blocks in `AI_Docker_Complete.ps1` were consolidated into one `Export-EmbeddedHelpers` function.
+
 ## [1.4.1] - 2026-07-11
 
 Hardens the AI router integration (loopback-only dashboards, held version pins, real uninstall) and adds CLI routing through the router. Force Rebuild/recreate once for the loopback port binding and the updated `~/.bashrc` managed block.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OpenCode CLI is now installed in the container** (`opencode-ai@1.17.18`, command `opencode`) and listed in the workspace welcome banner. Authenticate inside the container with `opencode auth login`. Like the other tools it participates in install status/repair and the weekly updater, and the wizard's install progress tracks it (now 9 tools).
 - **The launcher can now update itself.** When a new release is detected at startup, "Yes" downloads the new EXE, verifies its SHA256 against the release's published checksum, swaps the file in after the app exits, and relaunches automatically. An unverified or failed download changes nothing and falls back to the manual download page. ("No" still opens the download page; "Cancel" skips.)
 
 ### Changed

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -210,7 +210,7 @@ TOOL_AUTH_DIR="/home/$USER_NAME/.tool-auth"
 mkdir -p "$TOOL_AUTH_DIR"
 
 # Create subdirs and symlink each tool's config path
-for tool_dir in gh openai gemini codex; do
+for tool_dir in gh openai gemini codex opencode opencode-data; do
     mkdir -p "$TOOL_AUTH_DIR/$tool_dir"
 done
 
@@ -218,13 +218,20 @@ done
 # before removing the source: on failure the original directory (and its
 # credentials) stays in place and in use, and no broken symlink is created.
 mkdir -p "/home/$USER_NAME/.config"
-for tool_dir in gh openai gemini; do
+for tool_dir in gh openai gemini opencode; do
     config_path="/home/$USER_NAME/.config/$tool_dir"
     volume_path="$TOOL_AUTH_DIR/$tool_dir"
     if ! safe_migrate_dir "$config_path" "$volume_path"; then
         entrypoint_log "WARN" "Migration of $config_path failed - continuing with the original directory"
     fi
 done
+
+# OpenCode keeps credentials (auth.json) in its XDG data dir, not ~/.config
+mkdir -p "/home/$USER_NAME/.local/share"
+OPENCODE_DATA="/home/$USER_NAME/.local/share/opencode"
+if ! safe_migrate_dir "$OPENCODE_DATA" "$TOOL_AUTH_DIR/opencode-data"; then
+    entrypoint_log "WARN" "Migration of $OPENCODE_DATA failed - continuing with the original directory"
+fi
 
 # Symlink ~/.codex separately (not under ~/.config)
 CODEX_CONFIG="/home/$USER_NAME/.codex"
@@ -245,6 +252,8 @@ fi
 chown -R "$USER_NAME:$USER_NAME" "$TOOL_AUTH_DIR"
 chown -R "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.config"
 chown -h "$USER_NAME:$USER_NAME" "$CODEX_CONFIG" 2>/dev/null || true
+chown -h "$USER_NAME:$USER_NAME" "$OPENCODE_DATA" 2>/dev/null || true
+chown "$USER_NAME:$USER_NAME" "/home/$USER_NAME/.local" "/home/$USER_NAME/.local/share" 2>/dev/null || true
 entrypoint_log "INFO" "Tool-auth persistence setup complete"
 
 # Ensure the AI router data volume exists with correct ownership. 9router and OmniRoute each
@@ -330,6 +339,7 @@ elif [ -f "$HOME/.cli_tools_installed" ]; then
   echo "|   * gh           - GitHub CLI                               |"
   echo "|   * gemini       - Google Gemini CLI                        |"
   echo "|   * codex        - OpenAI Codex CLI                         |"
+  echo "|   * opencode     - OpenCode AI coding agent (TUI)           |"
   echo "|   * python3      - OpenAI Python SDK (import openai)        |"
   echo "|   * 9router      - Unified AI router (dashboard :20128)     |"
   echo "|   * omniroute    - Unified AI router (alt. to 9router)      |"

--- a/docker/install_cli_tools.sh
+++ b/docker/install_cli_tools.sh
@@ -113,6 +113,7 @@ tool_healthy() {
         gemini)     command_exists gemini || pip3 show gemini-cli >/dev/null 2>&1 ;;
         codex)      command_exists codex ;;
         vibe-kanban) npm list -g vibe-kanban >/dev/null 2>&1 ;;
+        opencode)   npm list -g opencode-ai >/dev/null 2>&1 ;;
         9router)    npm list -g 9router >/dev/null 2>&1 ;;
         omniroute)  npm list -g omniroute >/dev/null 2>&1 ;;
         openai)     pip3 show openai >/dev/null 2>&1 ;;
@@ -308,6 +309,9 @@ get_version() {
         vibe-kanban)
             npm list -g vibe-kanban 2>/dev/null | grep 'vibe-kanban' | cut -d'@' -f2 || echo "not installed"
             ;;
+        opencode)
+            npm list -g opencode-ai 2>/dev/null | grep 'opencode-ai' | cut -d'@' -f2 || echo "not installed"
+            ;;
         9router)
             npm list -g 9router 2>/dev/null | grep '9router' | cut -d'@' -f2 || echo "not installed"
             ;;
@@ -330,6 +334,7 @@ save_versions() {
     echo "vibe-kanban=$(get_version vibe-kanban)" >> "$TOOLS_VERSION_FILE"
     echo "9router=$(get_version 9router)" >> "$TOOLS_VERSION_FILE"
     echo "omniroute=$(get_version omniroute)" >> "$TOOLS_VERSION_FILE"
+    echo "opencode=$(get_version opencode)" >> "$TOOLS_VERSION_FILE"
 }
 
 # Main installation function
@@ -599,6 +604,17 @@ install_cli_tools() {
         print_warning "OmniRoute installation failed - can be installed manually with: npm install -g omniroute"
     fi
 
+    # 8. Install OpenCode (open-source multi-provider AI coding agent TUI;
+    # authenticate inside the container with: opencode auth login)
+    update_install_status "OpenCode CLI" "npm"
+    if ! should_install opencode; then
+        : # already working - skipped in repair mode
+    elif npm_install_with_retry "opencode-ai@1.17.18" "/tmp/opencode_install.log"; then
+        print_success "OpenCode installed successfully"
+    else
+        print_warning "OpenCode installation failed - can be installed manually with: npm install -g opencode-ai"
+    fi
+
     # Pin manifest consumed by auto_update.sh (one name@version per line).
     printf '%s\n%s\n' "$pinned_9router" "$pinned_omniroute" > "${HOME}/.npm-pinned-tools"
 
@@ -622,11 +638,11 @@ install_cli_tools() {
 # propagate a nonzero exit for a genuinely broken environment).
 create_marker_file() {
     local failed_tools="" failed_required=0 tool
-    local all_tools="claude gh gemini codex vibe-kanban 9router omniroute openai"
+    local all_tools="claude gh gemini codex vibe-kanban opencode 9router omniroute openai"
     # Deliberately uninstalled routers must not count as a partial install,
     # or every container start would run --repair and reinstall them.
     if [ -f "$ROUTER_OPTOUT_FILE" ]; then
-        all_tools="claude gh gemini codex vibe-kanban openai"
+        all_tools="claude gh gemini codex vibe-kanban opencode openai"
     fi
 
     for tool in $all_tools; do

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -85,6 +85,7 @@ Rules a change can silently break without any test failing locally. Read before 
 `AI_Docker_Complete.ps1` runs inside a ps2exe host on the end user's machine, where the Windows **default** execution policy blocks loading any `.ps1` file from disk. Therefore, inside the EXE's own process:
 
 - **Never dot-source an extracted `.ps1` file** (`. $path`). Load embedded content instead: `. ([ScriptBlock]::Create((Get-EmbeddedFileContent 'name.ps1')))`.
+- **Never use PS 5.1 cmdlets that are actually `.psm1`-shipped functions** — `Get-FileHash`, `New-TemporaryFile`, `New-Guid`, `Format-Hex`, etc. Their module script can't autoload under `Restricted` policy, and the error surfaces as a blocking popup. Use .NET equivalents (the template's `Get-Sha256Hex` exists for exactly this reason). Binary cmdlets (`Invoke-WebRequest`, `Get-Content`, …) are fine.
 - Child scripts are exempt — they are launched as separate processes with `-ExecutionPolicy Bypass` (keep that flag).
 - CI's `exe-smoke` job launches the built EXE under `Restricted` policy to enforce this (`scripts/build/test_exe_smoke.ps1`); the release workflow runs the same gate before publishing.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -75,6 +75,48 @@ All logging functions sanitize before writing to disk:
 
 ---
 
+## Load-Bearing Invariants
+
+Rules a change can silently break without any test failing locally. Read before touching the areas they name.
+
+### The EXE must run under a `Restricted` execution policy
+
+`AI_Docker_Complete.ps1` runs inside a ps2exe host on the end user's machine, where the Windows **default** execution policy blocks loading any `.ps1` file from disk. Therefore, inside the EXE's own process:
+
+- **Never dot-source an extracted `.ps1` file** (`. $path`). Load embedded content instead: `. ([ScriptBlock]::Create((Get-EmbeddedFileContent 'name.ps1')))`.
+- Child scripts are exempt — they are launched as separate processes with `-ExecutionPolicy Bypass` (keep that flag).
+- CI's `exe-smoke` job launches the built EXE under `Restricted` policy to enforce this (`scripts/build/test_exe_smoke.ps1`); the release workflow runs the same gate before publishing.
+
+### Runtime is Windows PowerShell 5.1, everywhere
+
+The EXE embeds a 5.1 host and every child process is `powershell.exe` (never `pwsh.exe`). No PS7-only syntax (`??`, ternary) or .NET Core-only APIs — the dual 5.1/7 Pester CI matrix exists to catch this.
+
+### Managed `~/.bashrc` block versioning
+
+`docker/lib/entrypoint_helpers.sh` regenerates a marked block in the container user's `.bashrc` on every start. **Any change to the block's content requires bumping `MANAGED_BLOCK_VERSION`**, or existing containers keep the old block forever (same version = no-op). User-authored content outside the markers must survive byte-for-byte.
+
+### Install marker semantics (`~/.cli_tools_installed`)
+
+`STATUS=ok|partial` is parsed by the entrypoint: `partial` triggers `install_cli_tools.sh --repair` on the next container start, which reinstalls anything unhealthy. Consequences:
+
+- A tool that is *deliberately* absent must be excluded from the marker's tool list, or repair will resurrect it. The AI router uninstall does this via the opt-out file `~/.router-data/routers-optout` — respect it in any new install/repair path.
+- Never write `STATUS=ok` while a required tool (`claude gh codex`) is broken.
+
+### npm version pins are literals, and the updater must not defeat them
+
+- CI's `check-pinned-versions` job **greps `install_cli_tools.sh` for literal `name@version` strings** (e.g. `9router@0.5.18`). Keep the pins as literals in that file even when refactoring into variables.
+- The weekly `auto_update.sh` runs a blanket `npm update -g`. Packages whose version must only change via a release (currently the credential-holding routers) are listed in the pin manifest `~/.npm-pinned-tools`, written by `install_cli_tools.sh` and re-applied by `auto_update.sh` after every update run. New "pinned forever" tools go in that manifest, not in ad-hoc updater logic.
+
+### Published ports bind to the host loopback interface only
+
+`docker-compose.yml` publishes the web dashboards as `127.0.0.1:<port>:<port>`. The router dashboard stores linked AI provider credentials and has no authentication — never publish it (or new web UIs) without the `127.0.0.1` prefix. Remote/mobile access goes through the SSH ports in `docker-compose.mobile.yml`, not through dashboard ports.
+
+### CLI routing contract
+
+`~/.router-data/cli-routing.env` (written by `configure_tools.sh`, mode 600) exports `OPENAI_BASE_URL`/`OPENAI_API_KEY` (and optionally the Anthropic equivalents) and is sourced by the managed `.bashrc` block. Absent file = routing disabled and CLIs talk to providers directly. Anything that creates or removes it must go through the AI Router menu's logic so enable/disable stays symmetric.
+
+---
+
 ## Build System
 
 ### Adding a New File to the .exe
@@ -169,8 +211,8 @@ Scripts are mounted read-only. Only for local development.
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `ci.yml` | Push/PR to main | PowerShell syntax check, Pester tests, Dockerfile validation, pinned version check |
-| `release.yml` | Push `v*.*.*` tag | Builds .exe on windows-latest, creates GitHub release with checksum |
+| `ci.yml` | Push/PR to main | PowerShell syntax check, Pester tests (5.1 + 7), bash suites, Dockerfile validation, pinned version check, **EXE smoke test** (builds the real EXE and launches it under a `Restricted` execution policy) |
+| `release.yml` | Push `v*.*.*` tag | Builds .exe on windows-latest, smoke-tests it under `Restricted` policy, creates GitHub release with checksums |
 
 ### Pester Tests
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -107,6 +107,10 @@ The EXE embeds a 5.1 host and every child process is `powershell.exe` (never `pw
 - CI's `check-pinned-versions` job **greps `install_cli_tools.sh` for literal `name@version` strings** (e.g. `9router@0.5.18`). Keep the pins as literals in that file even when refactoring into variables.
 - The weekly `auto_update.sh` runs a blanket `npm update -g`. Packages whose version must only change via a release (currently the credential-holding routers) are listed in the pin manifest `~/.npm-pinned-tools`, written by `install_cli_tools.sh` and re-applied by `auto_update.sh` after every update run. New "pinned forever" tools go in that manifest, not in ad-hoc updater logic.
 
+### Release asset names are an API (self-update depends on them)
+
+`Install-Update` in `AI_Docker_Complete.ps1` locates release assets **by exact name**: `AI_Docker_Manager_v<version>.exe` (fallback `AI_Docker_Manager.exe`) and the matching `<name>.sha256` file, and refuses to install anything whose checksum asset is missing or mismatched. Renaming release assets, changing the checksum file format (`<hash>  <filename>`), or dropping the `.sha256` uploads silently breaks self-update for every deployed EXE.
+
 ### Published ports bind to the host loopback interface only
 
 `docker-compose.yml` publishes the web dashboards as `127.0.0.1:<port>:<port>`. The router dashboard stores linked AI provider credentials and has no authentication — never publish it (or new web UIs) without the `127.0.0.1` prefix. Remote/mobile access goes through the SSH ports in `docker-compose.mobile.yml`, not through dashboard ports.
@@ -240,9 +244,9 @@ A pre-commit hook in `.git/hooks/pre-commit` enforces this — commits will be r
 
 Before creating a release:
 
+- [ ] `VERSION` — the single source of truth; the build script and release workflow read it (ps2exe `-version` and the EXE file name are derived automatically)
 - [ ] `scripts/AI_Docker_Complete.ps1` — `$script:AppVersion = "X.Y.Z"`
 - [ ] `scripts/AI_Docker_Launcher.ps1` — `$script:AppVersion = "X.Y.Z"`
-- [ ] `scripts/build/build_complete_exe.ps1` — ps2exe `-version "X.Y.Z.0"`
 - [ ] `README.md` — download badge version
 - [ ] `CHANGELOG.md` — new version section
 - [ ] `docs/MIGRATION.md` — version history row

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -38,6 +38,7 @@ Windows (.exe)                          Docker Container (Linux)
 | OpenAI Codex CLI | `codex` | npm (`@openai/codex`) |
 | OpenAI Python SDK | `python3 -c "import openai"` | pip |
 | Vibe Kanban | `vibe-kanban` | npm |
+| OpenCode | `opencode` | npm (`opencode-ai`) |
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,7 +75,9 @@ All bash suites run without Docker — they assert on script structure and use t
 
 ### CI
 
-`.github/workflows/ci.yml` runs on every push/PR to main: Linux PowerShell syntax/Pester, Windows PowerShell 5.1 and PowerShell 7 Pester, all bash suites, Dockerfile validation, blocking ShellCheck errors, visible nonblocking ShellCheck warnings, hadolint, release-version consistency, and pinned-version checks. `.github/workflows/docker-smoke.yml` uses uniquely named disposable resources for runtime build/readiness, migration, cron, router, mobile-override, and recreate-persistence checks.
+`.github/workflows/ci.yml` runs on every push/PR to main: Linux PowerShell syntax/Pester, Windows PowerShell 5.1 and PowerShell 7 Pester, all bash suites, Dockerfile validation, blocking ShellCheck errors, visible nonblocking ShellCheck warnings, hadolint, release-version consistency, pinned-version checks, and an **EXE smoke test** that builds the real executable with ps2exe and launches it under a `Restricted` execution policy (`scripts/build/test_exe_smoke.ps1` — the only check that exercises the compiled artifact rather than the scripts). `.github/workflows/docker-smoke.yml` uses uniquely named disposable resources for runtime build/readiness, migration, cron, router, mobile-override, and recreate-persistence checks.
+
+Before changing the managed `.bashrc` block, install markers, npm pins, published ports, or anything inside the EXE template, read **[CLAUDE.md → Load-Bearing Invariants](CLAUDE.md#load-bearing-invariants)** — those areas have rules that no local test enforces.
 
 ## Shell Scripts & Line Endings
 

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -85,6 +85,33 @@ function Write-AppLog {
     }
 }
 
+# SHA256 via .NET only. Get-FileHash must NOT be used inside this EXE: in
+# Windows PowerShell 5.1 it is a FUNCTION shipped in a .psm1, and a Restricted
+# execution policy (the Windows default) blocks that module script from
+# autoloading - the resulting error surfaces as a blocking popup at startup.
+function Get-Sha256Hex {
+    param(
+        [byte[]]$Bytes,
+        [string]$FilePath
+    )
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        if ($FilePath) {
+            $stream = [System.IO.File]::OpenRead($FilePath)
+            try {
+                $hashBytes = $sha256.ComputeHash($stream)
+            } finally {
+                $stream.Dispose()
+            }
+        } else {
+            $hashBytes = $sha256.ComputeHash($Bytes)
+        }
+        return ([System.BitConverter]::ToString($hashBytes)).Replace('-', '')
+    } finally {
+        $sha256.Dispose()
+    }
+}
+
 Write-AppLog "========================================" "INFO"
 Write-AppLog "AI Docker Complete (Standalone) Started" "INFO"
 Write-AppLog "Log file: $script:LogFile" "INFO"
@@ -187,7 +214,7 @@ function Install-Update {
         Invoke-WebRequest -Uri $shaAsset.browser_download_url -OutFile $shaFile -UseBasicParsing
 
         $expectedHash = ((Get-Content $shaFile -Raw).Trim() -split '\s+')[0]
-        $actualHash = (Get-FileHash -Path $newExe -Algorithm SHA256).Hash
+        $actualHash = Get-Sha256Hex -FilePath $newExe
         Remove-Item $shaFile -Force -ErrorAction SilentlyContinue
         if (-not $expectedHash -or ($actualHash -ne $expectedHash)) {
             Write-AppLog "Self-update: SHA256 verification FAILED - downloaded file discarded" "ERROR"
@@ -358,7 +385,7 @@ function Extract-DockerFiles {
             $hashBuilder.Append($content) | Out-Null
         }
     }
-    $currentHash = (Get-FileHash -InputStream ([System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes($hashBuilder.ToString()))) -Algorithm SHA256).Hash
+    $currentHash = Get-Sha256Hex -Bytes ([System.Text.Encoding]::UTF8.GetBytes($hashBuilder.ToString()))
 
     # Check if files need updating
     $needsUpdate = $false
@@ -1025,30 +1052,41 @@ $btnExit.Add_Click({
 # Check if Docker Desktop is running on startup
 Write-AppLog "Checking if Docker Desktop is running..." "DEBUG"
 function Test-DockerRunning {
-    $dockerHelpers = Join-Path $filesDir 'docker_helpers.ps1'
-    $logUtils = Join-Path $filesDir 'log_utils.ps1'
-    if (-not (Test-Path $dockerHelpers) -or -not (Test-Path $logUtils)) {
-        Extract-DockerFiles
-        Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1') | Out-Null
-    }
-
-    # Load in-process from embedded content, not the extracted files:
-    # dot-sourcing a .ps1 from disk is subject to the machine's execution
-    # policy (Restricted by default), which the compiled EXE inherits. The
-    # files above are still extracted for the child launch scripts, which
-    # run with -ExecutionPolicy Bypass.
-    foreach ($helperName in @('log_utils.ps1', 'docker_helpers.ps1')) {
-        $helperContent = Get-EmbeddedFileContent $helperName
-        if ($helperContent) {
-            . ([ScriptBlock]::Create($helperContent))
+    # Any unhandled error in here becomes a blocking ps2exe popup at startup
+    # (the failure mode the exe-smoke CI job watches for), so every step is
+    # logged and failures degrade to "Docker not detected" instead of a hang.
+    try {
+        $dockerHelpers = Join-Path $filesDir 'docker_helpers.ps1'
+        $logUtils = Join-Path $filesDir 'log_utils.ps1'
+        if (-not (Test-Path $dockerHelpers) -or -not (Test-Path $logUtils)) {
+            Write-AppLog "Docker check: extracting Docker files and helper scripts..." "DEBUG"
+            Extract-DockerFiles
+            Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1') | Out-Null
+            Write-AppLog "Docker check: extraction complete" "DEBUG"
         }
+
+        # Load in-process from embedded content, not the extracted files:
+        # dot-sourcing a .ps1 from disk is subject to the machine's execution
+        # policy (Restricted by default), which the compiled EXE inherits. The
+        # files above are still extracted for the child launch scripts, which
+        # run with -ExecutionPolicy Bypass.
+        foreach ($helperName in @('log_utils.ps1', 'docker_helpers.ps1')) {
+            $helperContent = Get-EmbeddedFileContent $helperName
+            if ($helperContent) {
+                . ([ScriptBlock]::Create($helperContent))
+            }
+        }
+        Write-AppLog "Docker check: helper modules loaded" "DEBUG"
+        if (Get-Command DockerOk -ErrorAction SilentlyContinue) {
+            return DockerOk -TimeoutSeconds 30
+        }
+        Write-AppLog "Docker helpers unavailable in embedded resources - falling back to direct docker check" "WARN"
+        docker info 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        Write-AppLog "Docker check failed unexpectedly: $($_.Exception.Message)" "ERROR"
+        return $false
     }
-    if (Get-Command DockerOk -ErrorAction SilentlyContinue) {
-        return DockerOk -TimeoutSeconds 30
-    }
-    Write-AppLog "Docker helpers unavailable in embedded resources - falling back to direct docker check" "WARN"
-    docker info 2>$null | Out-Null
-    return ($LASTEXITCODE -eq 0)
 }
 
 $dockerRunning = Test-DockerRunning

--- a/scripts/AI_Docker_Complete.ps1
+++ b/scripts/AI_Docker_Complete.ps1
@@ -130,6 +130,7 @@ function Check-ForUpdates {
                     DownloadUrl = $response.assets | Where-Object { $_.name -like "*.exe" } | Select-Object -First 1 -ExpandProperty browser_download_url
                     ReleaseUrl = $response.html_url
                     ReleaseNotes = $response.body
+                    Assets = $response.assets
                 }
             }
         }
@@ -137,6 +138,88 @@ function Check-ForUpdates {
     } catch {
         Write-AppLog "Update check failed: $($_.Exception.Message)" "DEBUG"
         return @{ UpdateAvailable = $false; Error = $_.Exception.Message }
+    }
+}
+
+# Download the new EXE, verify its SHA256 against the release's published
+# checksum, and hand off to a small updater script that swaps the file once
+# this process exits, then relaunches it. Returns $true when the handoff
+# started (the caller must exit immediately); $false means nothing was changed
+# and the caller should fall back to the manual download page.
+function Install-Update {
+    param($UpdateInfo)
+
+    try {
+        # Only a compiled EXE can self-replace; running as a plain .ps1 (dev) cannot.
+        $currentExe = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+        if ([System.IO.Path]::GetFileName($currentExe) -match '^(powershell|pwsh)') {
+            Write-AppLog "Self-update skipped: running as a script, not a compiled EXE" "WARN"
+            return $false
+        }
+
+        $latest = $UpdateInfo.LatestVersion
+        $assets = @($UpdateInfo.Assets)
+        # Prefer the versioned asset; fall back to the stable-named copy.
+        $exeAsset = $assets | Where-Object { $_.name -eq "AI_Docker_Manager_v$latest.exe" } | Select-Object -First 1
+        if (-not $exeAsset) {
+            $exeAsset = $assets | Where-Object { $_.name -eq 'AI_Docker_Manager.exe' } | Select-Object -First 1
+        }
+        if (-not $exeAsset) {
+            Write-AppLog "Self-update: no known EXE asset on the release" "WARN"
+            return $false
+        }
+        $shaAsset = $assets | Where-Object { $_.name -eq "$($exeAsset.name).sha256" } | Select-Object -First 1
+        if (-not $shaAsset) {
+            Write-AppLog "Self-update: release has no SHA256 checksum for $($exeAsset.name) - refusing an unverified update" "WARN"
+            return $false
+        }
+
+        $updateDir = Join-Path $appDataDir "updates"
+        if (-not (Test-Path $updateDir)) {
+            New-Item -ItemType Directory -Path $updateDir -Force | Out-Null
+        }
+        $newExe = Join-Path $updateDir $exeAsset.name
+        $shaFile = "$newExe.sha256"
+
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
+        Write-AppLog "Self-update: downloading $($exeAsset.name) (v$latest)" "INFO"
+        Invoke-WebRequest -Uri $exeAsset.browser_download_url -OutFile $newExe -UseBasicParsing
+        Invoke-WebRequest -Uri $shaAsset.browser_download_url -OutFile $shaFile -UseBasicParsing
+
+        $expectedHash = ((Get-Content $shaFile -Raw).Trim() -split '\s+')[0]
+        $actualHash = (Get-FileHash -Path $newExe -Algorithm SHA256).Hash
+        Remove-Item $shaFile -Force -ErrorAction SilentlyContinue
+        if (-not $expectedHash -or ($actualHash -ne $expectedHash)) {
+            Write-AppLog "Self-update: SHA256 verification FAILED - downloaded file discarded" "ERROR"
+            Remove-Item $newExe -Force -ErrorAction SilentlyContinue
+            return $false
+        }
+        Write-AppLog "Self-update: SHA256 verified" "INFO"
+
+        # The running EXE file is locked, so a helper script retries the copy
+        # until this process exits, then relaunches the updated EXE.
+        $updaterScript = Join-Path $updateDir "apply_update.cmd"
+        $updaterContent = @"
+@echo off
+set RETRIES=60
+:loop
+copy /y "$newExe" "$currentExe" >nul 2>&1
+if not errorlevel 1 goto done
+set /a RETRIES-=1
+if %RETRIES% leq 0 exit /b 1
+timeout /t 1 /nobreak >nul
+goto loop
+:done
+del "$newExe" >nul 2>&1
+start "" "$currentExe"
+"@
+        [System.IO.File]::WriteAllText($updaterScript, $updaterContent)
+        Write-AppLog "Self-update: handing off to updater and exiting" "INFO"
+        Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "`"$updaterScript`"" -WindowStyle Hidden
+        return $true
+    } catch {
+        Write-AppLog "Self-update failed: $($_.Exception.Message) - falling back to manual download" "ERROR"
+        return $false
     }
 }
 
@@ -236,6 +319,25 @@ function Get-EmbeddedFileContent {
     }
     Write-AppLog "WARNING: File $fileName not found in embedded resources" "WARN"
     return $null
+}
+
+# Write embedded helper scripts to the docker-files folder for child processes,
+# which run with -ExecutionPolicy Bypass and dot-source them from disk. (This
+# process itself must never dot-source them - see Load-Bearing Invariants in
+# docs/CLAUDE.md; load embedded content via [ScriptBlock]::Create() instead.)
+# Returns $true only when every requested helper was found and written.
+function Export-EmbeddedHelpers {
+    param([string[]]$Names)
+    $allOk = $true
+    foreach ($name in $Names) {
+        $content = Get-EmbeddedFileContent $name
+        if ($content) {
+            [System.IO.File]::WriteAllText((Join-Path $filesDir $name), $content, [System.Text.UTF8Encoding]::new($false))
+        } else {
+            $allOk = $false
+        }
+    }
+    return $allOk
 }
 
 # Function to silently extract Docker-required files and documentation (no popups, no console output)
@@ -563,33 +665,13 @@ $btnSetup.Add_Click({
                 Write-AppLog "WARNING: wsl_config.ps1 not found in embedded resources - WSL detection may fail" "WARN"
             }
 
-            # Extract log_utils.ps1 (dot-sourced by launch scripts for shared logging)
-            $logUtilsContent = Get-EmbeddedFileContent 'log_utils.ps1'
-            if ($logUtilsContent) {
-                $logUtilsScript = Join-Path $filesDir "log_utils.ps1"
-                [System.IO.File]::WriteAllText($logUtilsScript, $logUtilsContent, [System.Text.UTF8Encoding]::new($false))
-                Write-AppLog "Log utils helper written to: [$logUtilsScript]" "DEBUG"
-            }
-
-            # Extract setup_utils.ps1 (dot-sourced by setup_wizard.ps1 for Fix-LineEndings and password cleanup)
-            $setupUtilsContent = Get-EmbeddedFileContent 'setup_utils.ps1'
-            if ($setupUtilsContent) {
-                $setupUtilsScript = Join-Path $filesDir "setup_utils.ps1"
-                [System.IO.File]::WriteAllText($setupUtilsScript, $setupUtilsContent, [System.Text.UTF8Encoding]::new($false))
-                Write-AppLog "Setup utils helper written to: [$setupUtilsScript]" "DEBUG"
-            }
-
-            # Extract docker_helpers.ps1 and env_utils.ps1 (dot-sourced by setup_wizard.ps1
-            # for Wait-ContainerReady, image name constants, and .env helpers)
-            $dockerHelpersContent = Get-EmbeddedFileContent 'docker_helpers.ps1'
-            if ($dockerHelpersContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir "docker_helpers.ps1"), $dockerHelpersContent, [System.Text.UTF8Encoding]::new($false))
-                Write-AppLog "Docker helpers written for setup wizard" "DEBUG"
-            }
-            $envUtilsContent = Get-EmbeddedFileContent 'env_utils.ps1'
-            if ($envUtilsContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir "env_utils.ps1"), $envUtilsContent, [System.Text.UTF8Encoding]::new($false))
-                Write-AppLog "Env utils written for setup wizard" "DEBUG"
+            # Extract the wizard's dot-sourced dependencies: shared logging,
+            # Fix-LineEndings/password cleanup, Wait-ContainerReady + image
+            # name constants, and .env helpers.
+            if (Export-EmbeddedHelpers @('log_utils.ps1', 'setup_utils.ps1', 'docker_helpers.ps1', 'env_utils.ps1')) {
+                Write-AppLog "Setup wizard helper scripts written to: [$filesDir]" "DEBUG"
+            } else {
+                Write-AppLog "WARNING: some setup wizard helper scripts were missing from embedded resources" "WARN"
             }
 
             try {
@@ -741,8 +823,7 @@ $btnLaunch.Add_Click({
         $dockerHelpersContent = Get-EmbeddedFileContent 'docker_helpers.ps1'
         $logUtilsContent = Get-EmbeddedFileContent 'log_utils.ps1'
         if ($dockerHelpersContent -and $logUtilsContent) {
-            [System.IO.File]::WriteAllText((Join-Path $filesDir 'docker_helpers.ps1'), $dockerHelpersContent, [System.Text.UTF8Encoding]::new($false))
-            [System.IO.File]::WriteAllText((Join-Path $filesDir 'log_utils.ps1'), $logUtilsContent, [System.Text.UTF8Encoding]::new($false))
+            Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1') | Out-Null
             # Load in-process from embedded content, not the extracted files:
             # dot-sourcing a .ps1 from disk is subject to the machine's execution
             # policy (Restricted by default), which the compiled EXE inherits.
@@ -782,19 +863,8 @@ $btnLaunch.Add_Click({
             Write-AppLog "Writing launch script to: [$launchScript]" "DEBUG"
             [System.IO.File]::WriteAllText($launchScript, $launchContent, [System.Text.UTF8Encoding]::new($false))
 
-            # Extract log_utils.ps1 and docker_helpers.ps1 (dot-sourced by launch script)
-            $logUtilsContent = Get-EmbeddedFileContent 'log_utils.ps1'
-            if ($logUtilsContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir "log_utils.ps1"), $logUtilsContent, [System.Text.UTF8Encoding]::new($false))
-            }
-            $dockerHelpersContent = Get-EmbeddedFileContent 'docker_helpers.ps1'
-            if ($dockerHelpersContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir "docker_helpers.ps1"), $dockerHelpersContent, [System.Text.UTF8Encoding]::new($false))
-            }
-            $envUtilsContent = Get-EmbeddedFileContent 'env_utils.ps1'
-            if ($envUtilsContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir "env_utils.ps1"), $envUtilsContent, [System.Text.UTF8Encoding]::new($false))
-            }
+            # Extract the launch script's dot-sourced dependencies
+            Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1', 'env_utils.ps1') | Out-Null
             Write-AppLog "Launch script written successfully" "DEBUG"
 
             $form.Hide()
@@ -901,19 +971,8 @@ $btnVibeKanban.Add_Click({
                 Write-AppLog "Writing Vibe Kanban script to: [$vibeScript]" "DEBUG"
                 [System.IO.File]::WriteAllText($vibeScript, $vibeContent, [System.Text.UTF8Encoding]::new($false))
 
-                # Extract log_utils.ps1 and docker_helpers.ps1 (dot-sourced by launch script)
-                $logUtilsContent = Get-EmbeddedFileContent 'log_utils.ps1'
-                if ($logUtilsContent) {
-                    [System.IO.File]::WriteAllText((Join-Path $filesDir "log_utils.ps1"), $logUtilsContent, [System.Text.UTF8Encoding]::new($false))
-                }
-                $dockerHelpersContent = Get-EmbeddedFileContent 'docker_helpers.ps1'
-                if ($dockerHelpersContent) {
-                    [System.IO.File]::WriteAllText((Join-Path $filesDir "docker_helpers.ps1"), $dockerHelpersContent, [System.Text.UTF8Encoding]::new($false))
-                }
-                $envUtilsContent = Get-EmbeddedFileContent 'env_utils.ps1'
-                if ($envUtilsContent) {
-                    [System.IO.File]::WriteAllText((Join-Path $filesDir "env_utils.ps1"), $envUtilsContent, [System.Text.UTF8Encoding]::new($false))
-                }
+                # Extract the launch script's dot-sourced dependencies
+                Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1', 'env_utils.ps1') | Out-Null
                 Write-AppLog "Vibe Kanban launch script written successfully" "DEBUG"
 
                 $form.Hide()
@@ -970,12 +1029,7 @@ function Test-DockerRunning {
     $logUtils = Join-Path $filesDir 'log_utils.ps1'
     if (-not (Test-Path $dockerHelpers) -or -not (Test-Path $logUtils)) {
         Extract-DockerFiles
-        foreach ($helperName in @('log_utils.ps1', 'docker_helpers.ps1')) {
-            $helperContent = Get-EmbeddedFileContent $helperName
-            if ($helperContent) {
-                [System.IO.File]::WriteAllText((Join-Path $filesDir $helperName), $helperContent, [System.Text.UTF8Encoding]::new($false))
-            }
-        }
+        Export-EmbeddedHelpers @('log_utils.ps1', 'docker_helpers.ps1') | Out-Null
     }
 
     # Load in-process from embedded content, not the extracted files:
@@ -1074,18 +1128,35 @@ if ($updateInfo.UpdateAvailable) {
     $updateMessage = "A new version is available!`n`n" +
                      "Current: v$($updateInfo.CurrentVersion)`n" +
                      "Latest: v$($updateInfo.LatestVersion)`n`n" +
-                     "Would you like to open the download page?"
+                     "Yes = Install it now (downloaded, checksum-verified, app restarts)`n" +
+                     "No = Open the download page instead`n" +
+                     "Cancel = Skip this update"
 
     $result = [System.Windows.Forms.MessageBox]::Show(
         $updateMessage,
         "Update Available",
-        [System.Windows.Forms.MessageBoxButtons]::YesNo,
+        [System.Windows.Forms.MessageBoxButtons]::YesNoCancel,
         [System.Windows.Forms.MessageBoxIcon]::Information
     )
 
     if ($result -eq [System.Windows.Forms.DialogResult]::Yes) {
+        Write-AppLog "User chose to install the update now" "INFO"
+        if (Install-Update -UpdateInfo $updateInfo) {
+            exit 0
+        }
+        # The verified install did not start - offer the manual path instead.
+        [System.Windows.Forms.MessageBox]::Show(
+            "The automatic update could not be completed, so the download page will open instead.`n`nDetails are in the log:`n$script:LogFile",
+            "Update",
+            [System.Windows.Forms.MessageBoxButtons]::OK,
+            [System.Windows.Forms.MessageBoxIcon]::Warning
+        ) | Out-Null
+        Start-Process $updateInfo.ReleaseUrl
+    } elseif ($result -eq [System.Windows.Forms.DialogResult]::No) {
         Write-AppLog "User chose to open download page" "INFO"
         Start-Process $updateInfo.ReleaseUrl
+    } else {
+        Write-AppLog "User skipped the update" "INFO"
     }
 }
 

--- a/scripts/build/build_complete_exe.ps1
+++ b/scripts/build/build_complete_exe.ps1
@@ -127,6 +127,29 @@ foreach ($fileName in $files.Keys) {
     Write-Host "    Embedded: $fileName -> $placeholder" -ForegroundColor Gray
 }
 
+# Round-trip validation: every source file's exact Base64 payload must now be
+# present (quoted) in the bundled script. This catches the silent failure mode
+# where a file is in $filesToEmbed but its placeholder is missing from the
+# template's $script:EmbeddedFiles - Replace() is then a no-op and the EXE
+# would ship without the file. (The unreplaced-placeholder check below covers
+# the opposite direction: placeholder present, build entry missing.)
+$roundTripFailures = @()
+foreach ($fileName in $files.Keys) {
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($files[$fileName])
+    $base64Content = [System.Convert]::ToBase64String($bytes)
+    if (-not $bundledScript.Contains("'$base64Content'")) {
+        $roundTripFailures += $fileName
+    }
+}
+if ($roundTripFailures.Count -gt 0) {
+    Write-Host "  ERROR Round-trip validation failed - these files are in `$filesToEmbed but their content is NOT embedded in the bundled script:" -ForegroundColor Red
+    foreach ($fileName in $roundTripFailures) {
+        Write-Host "    - $fileName (is its placeholder present in AI_Docker_Complete.ps1's `$script:EmbeddedFiles?)" -ForegroundColor Red
+    }
+    exit 1
+}
+Write-Host "  OK Round-trip validation: all $($files.Count) embedded files verified" -ForegroundColor Green
+
 # Save the bundled script to project root
 $projectRoot = Join-Path $PSScriptRoot "..\..\"
 $bundledScriptPath = Join-Path $projectRoot "AI_Docker_Complete_Bundled.ps1"

--- a/scripts/build/test_exe_smoke.ps1
+++ b/scripts/build/test_exe_smoke.ps1
@@ -1,0 +1,131 @@
+# test_exe_smoke.ps1 - Launch the built EXE under a Restricted execution policy
+# and assert it survives startup (embedded helper loading + Docker check).
+#
+# This exists because the Pester/bash suites test the SCRIPTS, never the
+# compiled artifact: the v1.4.0 "running scripts is disabled on this system"
+# launcher bug shipped precisely because nothing ever ran the EXE on a machine
+# with the Windows default execution policy. Windows only.
+#
+# Success is defined by log markers that appear only AFTER Test-DockerRunning
+# has returned - i.e. after the embedded helper modules loaded and DockerOk
+# executed, the exact code path the execution-policy bug broke:
+#   - "Docker Desktop is not running"    (no Docker daemon: warning path)
+#   - "Performing startup update check"  (Docker present: fully past the check)
+#
+# Exit codes: 0 = startup marker reached, 1 = failure signature/crash/timeout.
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExePath,
+
+    [int]$TimeoutSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $ExePath)) {
+    Write-Host "[FAIL] EXE not found: $ExePath" -ForegroundColor Red
+    exit 1
+}
+
+$logFile = Join-Path $env:LOCALAPPDATA 'AI-Docker-CLI\logs\ai-docker.log'
+
+$successPatterns = @(
+    'Docker Desktop is not running',
+    'Performing startup update check'
+)
+$failurePatterns = @(
+    'running scripts is disabled',
+    'is not recognized as the name of a cmdlet'
+)
+
+# The whole point of this test: the EXE must work under the Windows DEFAULT
+# policy. The EXE's ps2exe host reads the Windows PowerShell policy, so it is
+# set via powershell.exe (a pwsh-side Set-ExecutionPolicy would not apply).
+$previousPolicy = (& powershell.exe -NoProfile -Command 'Get-ExecutionPolicy -Scope CurrentUser').Trim()
+& powershell.exe -NoProfile -Command 'Set-ExecutionPolicy Restricted -Scope CurrentUser -Force' | Out-Null
+Write-Host "[INFO] CurrentUser Windows PowerShell execution policy set to Restricted (was: $previousPolicy)"
+
+if (Test-Path $logFile) { Remove-Item $logFile -Force }
+
+$process = $null
+$status = 'timeout'
+$matched = ''
+try {
+    Write-Host "[INFO] Launching $ExePath (timeout ${TimeoutSeconds}s)..."
+    $process = Start-Process -FilePath $ExePath -PassThru
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+    while ((Get-Date) -lt $deadline) {
+        Start-Sleep -Seconds 2
+
+        $log = ''
+        if (Test-Path $logFile) {
+            $log = Get-Content $logFile -Raw -ErrorAction SilentlyContinue
+        }
+
+        if ($log) {
+            $failureHit = $failurePatterns | Where-Object { $log -match [regex]::Escape($_) } | Select-Object -First 1
+            if ($failureHit) {
+                $status = 'failure-signature'
+                $matched = $failureHit
+                break
+            }
+            $successHit = $successPatterns | Where-Object { $log -match [regex]::Escape($_) } | Select-Object -First 1
+            if ($successHit) {
+                $status = 'ok'
+                $matched = $successHit
+                break
+            }
+        }
+
+        # A GUI EXE that exits this early crashed (unhandled startup error).
+        # Grace-read the log once more on the next loop before concluding.
+        if ($process.HasExited) {
+            Start-Sleep -Seconds 2
+            $log = if (Test-Path $logFile) { Get-Content $logFile -Raw -ErrorAction SilentlyContinue } else { '' }
+            $successHit = $successPatterns | Where-Object { $log -and ($log -match [regex]::Escape($_)) } | Select-Object -First 1
+            if ($successHit) {
+                $status = 'ok'
+                $matched = $successHit
+            } else {
+                $status = 'exited'
+            }
+            break
+        }
+    }
+} finally {
+    if ($process -and -not $process.HasExited) {
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    }
+    & powershell.exe -NoProfile -Command "Set-ExecutionPolicy $previousPolicy -Scope CurrentUser -Force" | Out-Null
+    Write-Host "[INFO] CurrentUser execution policy restored to $previousPolicy"
+}
+
+Write-Host ''
+Write-Host '--- startup log ---'
+if (Test-Path $logFile) {
+    Get-Content $logFile -ErrorAction SilentlyContinue | Select-Object -Last 40 | ForEach-Object { Write-Host "  $_" }
+} else {
+    Write-Host '  (no log file was created)'
+}
+Write-Host '-------------------'
+Write-Host ''
+
+switch ($status) {
+    'ok' {
+        Write-Host "[PASS] EXE started under Restricted policy and reached startup marker: '$matched'" -ForegroundColor Green
+        exit 0
+    }
+    'failure-signature' {
+        Write-Host "[FAIL] Startup log contains failure signature: '$matched'" -ForegroundColor Red
+        exit 1
+    }
+    'exited' {
+        Write-Host '[FAIL] EXE exited during startup before reaching a success marker (crash?)' -ForegroundColor Red
+        exit 1
+    }
+    default {
+        Write-Host "[FAIL] No startup marker within ${TimeoutSeconds}s - the EXE is stuck or startup broke silently" -ForegroundColor Red
+        exit 1
+    }
+}

--- a/scripts/build/test_exe_smoke.ps1
+++ b/scripts/build/test_exe_smoke.ps1
@@ -35,7 +35,8 @@ $successPatterns = @(
 )
 $failurePatterns = @(
     'running scripts is disabled',
-    'is not recognized as the name of a cmdlet'
+    'is not recognized as the name of a cmdlet',
+    'Docker check failed unexpectedly'
 )
 
 # The whole point of this test: the EXE must work under the Windows DEFAULT

--- a/scripts/setup_wizard.ps1
+++ b/scripts/setup_wizard.ps1
@@ -1834,7 +1834,7 @@ $btnNext.Add_Click({
             # AI CLI tools will be auto-installed by entrypoint.sh
             $status.Text = 'Installing AI CLI tools suite...'
             Write-Host "[INFO] Container is auto-installing AI CLI tools..." -ForegroundColor Cyan
-            Write-Host "[INFO] Installing: Claude, GitHub CLI, Gemini, OpenAI SDK, Codex, Vibe Kanban, 9router, OmniRoute..." -ForegroundColor Yellow
+            Write-Host "[INFO] Installing: Claude, GitHub CLI, Gemini, OpenAI SDK, Codex, Vibe Kanban, 9router, OmniRoute, OpenCode..." -ForegroundColor Yellow
             Write-Host "[INFO] This will take 5-10 minutes on first run..." -ForegroundColor Yellow
             Write-Host "[INFO] This step requires internet connection" -ForegroundColor Yellow
 
@@ -1896,8 +1896,8 @@ $btnNext.Add_Click({
             }
 
             # Check installation progress by looking for the marker file
-            # 8 tools install sequentially (gh, Claude, Gemini, OpenAI SDK, Codex, Vibe Kanban,
-            # 9router, OmniRoute) - 5 minutes was routinely exceeded after the routers were added
+            # 9 tools install sequentially (gh, Claude, Gemini, OpenAI SDK, Codex, Vibe Kanban,
+            # 9router, OmniRoute, OpenCode) - 5 minutes was routinely exceeded after the routers were added
             $maxWaitTime = 600  # 10 minutes
             $waitedTime = 0
             $checkInterval = 3  # Check more frequently for better UI updates
@@ -1950,7 +1950,7 @@ $btnNext.Add_Click({
                         $script:lblCurrentTool.Text = "Installing $toolName via $pkgMgr..."
                         Write-Host "[STATUS] Installing: $toolName ($pkgMgr)" -ForegroundColor Cyan
 
-                        # Update progress based on which tool is currently installing (8 tools total)
+                        # Update progress based on which tool is currently installing (9 tools total)
                         # Names must match update_install_status calls in docker/install_cli_tools.sh
                         $toolProgress = switch ($toolName) {
                             'GitHub CLI' { 15 }
@@ -1958,9 +1958,10 @@ $btnNext.Add_Click({
                             'Google Gemini CLI' { 45 }
                             'OpenAI Python SDK' { 55 }
                             'OpenAI Codex CLI' { 65 }
-                            'Vibe Kanban' { 80 }
-                            '9router' { 90 }
-                            'OmniRoute' { 95 }
+                            'Vibe Kanban' { 78 }
+                            '9router' { 86 }
+                            'OmniRoute' { 92 }
+                            'OpenCode CLI' { 96 }
                             default { $progress.Value }  # Keep current if unknown
                         }
                         $progress.Value = $toolProgress

--- a/tests/test_install_cli_tools.sh
+++ b/tests/test_install_cli_tools.sh
@@ -42,6 +42,7 @@ case " $* " in
     *' --version '*) printf '10.0.0\n' ;;
     *' list -g --depth=0 '*) printf '/fake\n' ;;
     *' list -g vibe-kanban '*) printf 'vibe-kanban@1.0.0\n' ;;
+    *' list -g opencode-ai '*) printf 'opencode-ai@1.0.0\n' ;;
     *' list -g 9router '*) printf '9router@1.0.0\n' ;;
     *' list -g omniroute '*) printf 'omniroute@1.0.0\n' ;;
     *' view '*) printf '1.0.0\n' ;;


### PR DESCRIPTION
## Description

Four items (one of them a rescue: **PR #68's content never reached `main`** — its base was the release branch, and #67 merged that branch into `main` before #68 landed on it; this PR carries #68's commit to `main`).

**From #68 (re-delivered):** the compiled-EXE smoke test (`scripts/build/test_exe_smoke.ps1`, the `exe-smoke` CI job, the release-workflow gate) and the Load-Bearing Invariants documentation in `docs/CLAUDE.md`.

**New — verified launcher self-update.** When a newer release is detected at startup, "Yes" downloads the new EXE, verifies its SHA256 against the release's published checksum asset, hands off to a small updater that swaps the file once the process exits, and relaunches. Any failure (missing checksum asset, hash mismatch, download error) changes nothing and falls back to the manual download page. Release asset names are now part of the self-update contract, documented as a new load-bearing invariant.

**New — OpenCode CLI in the container.** `opencode-ai@1.17.18` installs as tool 8 with the same status/repair/version tracking as the other npm tools, appears in the workspace welcome banner (`opencode` command), and is tracked by the wizard's install progress (now 9 tools). Auth persists across rebuilds: `~/.config/opencode` joins the tool-auth symlink loop and the XDG data dir (`~/.local/share/opencode`, which holds `auth.json`) migrates into the tool-auth volume. Authenticate with `opencode auth login`. The CI pinned-version freshness check covers it.

**New — build hardening (containment).** `build_complete_exe.ps1` round-trip-verifies that every embedded file's exact Base64 payload is present in the bundled script, failing the build when a file is in `$filesToEmbed` but its placeholder is missing from the template — previously a silent no-op that shipped an EXE without the file. The five copy-pasted helper-extraction blocks in `AI_Docker_Complete.ps1` are consolidated into one `Export-EmbeddedHelpers` function. Also refreshes the version-bump checklist (ps2exe version/file name derive from `VERSION` automatically since 1.4.1).

## Related Issue

Follow-up to #67/#68; delivers #68's content to `main`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally (all touched PowerShell parses clean under the AST parser; ShellCheck error-severity clean; bash suites all pass: `test_bash_fixes` 38/38, `test_install_cli_tools` 16/16 — including the new opencode mock — `test_auth_persistence` 26/26, `test_router_utils` 13/13, `test_auto_update` 12/12; PSGallery is blocked in this sandbox so Pester runs in this PR's CI, which also exercises the modified template end-to-end via the `exe-smoke` job)
- [x] I have updated the documentation (CHANGELOG `[Unreleased]`, CLAUDE.md tools table + invariants + version-bump checklist)
- [x] I have added/updated tests (build round-trip validation; EXE smoke test; opencode test mock)
- [x] My code follows the project's coding style
- [x] I have checked that there are no merge conflicts

## Screenshots (if applicable)

N/A.

## Testing Instructions

1. This PR's CI is the main gate — in particular the `exe-smoke` job must build the modified template and launch it under `Restricted` policy.
2. OpenCode: Force Rebuild, open the workspace — the banner lists `opencode`; run `opencode --version`, then `opencode auth login`, rebuild again and confirm the login survived.
3. Self-update (needs a machine with an older release): run an old EXE after a newer release exists → "Yes" on the update dialog → the app restarts as the new version; the log shows "SHA256 verified".
4. Negative path: delete the `.sha256` assets from a draft release and confirm the updater refuses and falls back to the download page.
5. Build validation: remove any entry from `$script:EmbeddedFiles` in the template and run the build — it must fail naming the missing file.

## Additional Notes

Maintainer decisions reflected here: code signing skipped, both routers kept, full self-update, containment-level build hardening. A container Force Rebuild is required to get OpenCode and its auth persistence. The fully-merged release branch `claude/ai-docker-manager-error-dzd90t` can be deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtDhHrArRUeuCCFBAjDMVW