### PR TITLE
fix(codex): enable nested sandbox and trusted TLS

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -103,7 +103,11 @@ jobs:
             test "$(cat /etc/ai-docker-version)" = "'"$AI_DOCKER_VERSION"'"
             command -v claude
             command -v codex
+            command -v bwrap
+            bwrap --ro-bind / / /bin/true
             command -v configure-tools
+            test "$CODEX_CA_CERTIFICATE" = /etc/ssl/certs/ca-certificates.crt
+            test -r "$CODEX_CA_CERTIFICATE"
             test -L "$HOME/.config/gh"
             test -L "$HOME/.codex"
             crontab -l | grep -q auto_update.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to AI Docker CLI Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Codex now finds the system `bubblewrap` package and can create its nested Linux/WSL2 workspace sandbox inside the container.
+- Codex HTTPS, login, and WebSocket clients now use the container's system/custom CA bundle, preventing `UnknownIssuer` WebSocket fallback errors.
+
 ## [1.5.3] - 2026-07-11
 
 Launcher-only fix; no container rebuild needed.

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ docker exec -it ai-cli bash           # Shell access
 
 Proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY`) can be set in `docker/.env`. For a corporate CA, set `CUSTOM_CA_HOST_PATH` to an absolute PEM `.crt` path and include `docker-compose.ca.yml` with the base Compose file. See [Remote Access](docs/REMOTE_ACCESS.md#corporate-proxy-and-custom-ca).
 
+Codex uses Ubuntu's system CA bundle for HTTPS and WebSocket connections. The image also includes `bubblewrap`, and Compose permits the unprivileged namespaces required by Codex's Linux workspace sandbox. See [Codex Linux Sandbox](docs/REMOTE_ACCESS.md#codex-linux-sandbox).
+
 ### Diagnostics
 
 Inside the container, run `configure-tools --diagnose` for a sanitized classification of installation, binaries, authentication, router port, DNS/TLS, proxy, and container-version state.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     git \
     ca-certificates \
+    # Codex uses bubblewrap for its Linux/WSL2 workspace sandbox.
+    bubblewrap \
     gnupg \
     lsb-release \
     software-properties-common \

--- a/docker/docker-compose.ca.yml
+++ b/docker/docker-compose.ca.yml
@@ -8,6 +8,7 @@ services:
       NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/ai-docker-custom-ca.crt
       REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+      CODEX_CA_CERTIFICATE: /etc/ssl/certs/ca-certificates.crt
     volumes:
       - type: bind
         source: ${CUSTOM_CA_HOST_PATH:?Set CUSTOM_CA_HOST_PATH to an absolute .crt file path}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     # Fixed image name - referenced by the setup wizard and launchers
     image: ai-docker-cli:latest
     container_name: ai-cli
+    # Codex runs bubblewrap inside this development container. Docker's default
+    # seccomp profile blocks the unprivileged namespace creation bwrap needs;
+    # capabilities remain restricted and bwrap applies the inner sandbox.
+    security_opt:
+      - seccomp=unconfined
     environment:
       USER_NAME: ${USER_NAME}
       # Vibe Kanban configuration
@@ -44,6 +49,8 @@ services:
       NODE_EXTRA_CA_CERTS: ${NODE_EXTRA_CA_CERTS:-}
       REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-}
       SSL_CERT_FILE: ${SSL_CERT_FILE:-}
+      # Codex uses this bundle for HTTPS, login, and WebSocket connections.
+      CODEX_CA_CERTIFICATE: ${CODEX_CA_CERTIFICATE:-/etc/ssl/certs/ca-certificates.crt}
       CUSTOM_CA_CERT: ${CUSTOM_CA_CERT:-}
     secrets:
       - user_password

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,6 +69,7 @@ if [ -n "${CUSTOM_CA_CERT:-}" ]; then
         export NODE_EXTRA_CA_CERTS="${NODE_EXTRA_CA_CERTS:-$CUSTOM_CA_CERT}"
         export REQUESTS_CA_BUNDLE="${REQUESTS_CA_BUNDLE:-/etc/ssl/certs/ca-certificates.crt}"
         export SSL_CERT_FILE="${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}"
+        export CODEX_CA_CERTIFICATE="${CODEX_CA_CERTIFICATE:-/etc/ssl/certs/ca-certificates.crt}"
       else
         entrypoint_log "ERROR" "CUSTOM_CA_CERT is configured but unreadable"
         exit 1

--- a/docker/lib/entrypoint_helpers.sh
+++ b/docker/lib/entrypoint_helpers.sh
@@ -339,7 +339,7 @@ ensure_cron_daemon_running() {
 
 # Space-free, comma-joinable list consumed by `su -w`. Includes upper/lower case
 # variants because different tools read different casings.
-PROXY_CA_ENV_VARS="HTTP_PROXY,HTTPS_PROXY,NO_PROXY,ALL_PROXY,http_proxy,https_proxy,no_proxy,all_proxy,NODE_EXTRA_CA_CERTS,REQUESTS_CA_BUNDLE,SSL_CERT_FILE,CUSTOM_CA_CERT"
+PROXY_CA_ENV_VARS="HTTP_PROXY,HTTPS_PROXY,NO_PROXY,ALL_PROXY,http_proxy,https_proxy,no_proxy,all_proxy,NODE_EXTRA_CA_CERTS,REQUESTS_CA_BUNDLE,SSL_CERT_FILE,CODEX_CA_CERTIFICATE,CUSTOM_CA_CERT"
 
 # su_preserving_env <user> <command-string>
 # Runs `su - <user> -c <command>` while preserving proxy/CA vars across the

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -546,17 +546,29 @@ CUSTOM_CA_CERT=/usr/local/share/ca-certificates/ai-docker-custom.crt
 NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/ai-docker-custom.crt
 REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+CODEX_CA_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt
 ```
 
 ```powershell
 docker compose -f docker-compose.yml -f docker-compose.ca.yml up -d --build
 ```
 
-The override bind-mounts only the selected certificate read-only. Entrypoint startup rejects paths outside `/usr/local/share/ca-certificates/*.crt`, installs the CA idempotently, and makes the resulting system bundle available to Node, Python Requests, OpenSSL, npm, and pip. Run `configure-tools --diagnose` afterward; an API authentication HTTP response can still demonstrate successful DNS/TLS transport (the diagnostic reports `TLS=ok` plus the raw `HTTP_STATUS_*` codes, and only flags `TLS=failed` for genuine DNS/connection/timeout/SSL errors).
+The override bind-mounts only the selected certificate read-only. Entrypoint startup rejects paths outside `/usr/local/share/ca-certificates/*.crt`, installs the CA idempotently, and makes the resulting system bundle available to Node, Python Requests, OpenSSL, npm, pip, and Codex HTTPS/WebSocket connections. Run `configure-tools --diagnose` afterward; an API authentication HTTP response can still demonstrate successful DNS/TLS transport (the diagnostic reports `TLS=ok` plus the raw `HTTP_STATUS_*` codes, and only flags `TLS=failed` for genuine DNS/connection/timeout/SSL errors).
 
 Proxy and CA settings apply in every context, not just the entrypoint's own shell. The startup writes them to `/etc/profile.d/ai-docker-proxy.sh` so interactive `su -`/SSH login shells re-export them, whitelists them across the tool-installation `su -` calls, and has the weekly auto-update cron entry source that profile — so tool installs, updates, and manual sessions all honor the proxy/CA configuration on corporate networks.
 
 This feature extends local trust to the configured CA. Confirm the certificate fingerprint with your administrator before mounting it.
+
+## Codex Linux Sandbox
+
+Codex uses `bubblewrap` for workspace sandboxing on Linux and WSL2. The image includes the distribution package, and the Compose service disables Docker's default seccomp profile because it blocks the nested unprivileged namespace creation that `bubblewrap` requires. Docker capabilities remain restricted; do not add `privileged: true` or mount the Docker socket to work around namespace errors.
+
+After rebuilding, verify the nested sandbox prerequisite inside the container:
+
+```bash
+command -v bwrap
+bwrap --ro-bind / / /bin/true
+```
 
 ## Troubleshooting
 

--- a/tests/test_bash_fixes.sh
+++ b/tests/test_bash_fixes.sh
@@ -221,6 +221,25 @@ else
     fail "Dockerfile still installs unused pipx"
 fi
 
+# Codex Linux sandbox and TLS prerequisites
+if grep -qE '^[[:space:]]+bubblewrap \\' docker/Dockerfile; then
+    pass "Dockerfile installs bubblewrap for the Codex sandbox"
+else
+    fail "Dockerfile does not install bubblewrap"
+fi
+
+if grep -q 'seccomp=unconfined' docker/docker-compose.yml; then
+    pass "Compose permits nested bubblewrap namespaces"
+else
+    fail "Compose still blocks nested bubblewrap namespaces"
+fi
+
+if grep -q 'CODEX_CA_CERTIFICATE.*ca-certificates.crt' docker/docker-compose.yml; then
+    pass "Compose configures Codex system CA trust"
+else
+    fail "Compose does not configure CODEX_CA_CERTIFICATE"
+fi
+
 # CQ-024: Fix-LineEndings no stale claude_wrapper.sh reference
 if ! grep -q 'claude_wrapper' scripts/setup_utils.ps1; then
     pass "setup_utils.ps1 Fix-LineEndings list updated (CQ-024)"

--- a/tests/test_entrypoint_helpers.sh
+++ b/tests/test_entrypoint_helpers.sh
@@ -120,11 +120,13 @@ rm -rf "$profile_dir"
 assert_true "writes proxy/CA profile when vars are set" \
     env HTTP_PROXY="http://proxy.example:3128" NO_PROXY="localhost,127.0.0.1" \
         NODE_EXTRA_CA_CERTS="/usr/local/share/ca-certificates/ai-docker-custom-ca.crt" \
+        CODEX_CA_CERTIFICATE="/etc/ssl/certs/ca-certificates.crt" \
     bash -c "source '$ROOT_DIR/docker/lib/entrypoint_helpers.sh'; write_proxy_ca_profile '$profile_dir'"
 assert_true "generated profile exists" test -f "$profile_file"
 assert_true "profile exports HTTP_PROXY value" bash -c ". '$profile_file'; [ \"\$HTTP_PROXY\" = 'http://proxy.example:3128' ]"
 assert_true "profile exports NO_PROXY value" bash -c ". '$profile_file'; [ \"\$NO_PROXY\" = 'localhost,127.0.0.1' ]"
 assert_true "profile exports CA bundle value" bash -c ". '$profile_file'; [ \"\$NODE_EXTRA_CA_CERTS\" = '/usr/local/share/ca-certificates/ai-docker-custom-ca.crt' ]"
+assert_true "profile exports Codex CA bundle value" bash -c ". '$profile_file'; [ \"\$CODEX_CA_CERTIFICATE\" = '/etc/ssl/certs/ca-certificates.crt' ]"
 assert_false "profile omits unset vars" grep -q 'HTTPS_PROXY' "$profile_file"
 
 # Values containing single quotes are escaped safely.
@@ -138,13 +140,14 @@ assert_true "escaped value round-trips" bash -c ". '$profile_file'; [ \"\$HTTP_P
 printf 'stale\n' > "$profile_file"
 assert_true "clears profile when no vars set" \
     env -u HTTP_PROXY -u HTTPS_PROXY -u NO_PROXY -u ALL_PROXY -u http_proxy -u https_proxy \
-        -u no_proxy -u all_proxy -u NODE_EXTRA_CA_CERTS -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE -u CUSTOM_CA_CERT \
+        -u no_proxy -u all_proxy -u NODE_EXTRA_CA_CERTS -u REQUESTS_CA_BUNDLE -u SSL_CERT_FILE -u CODEX_CA_CERTIFICATE -u CUSTOM_CA_CERT \
     bash -c "source '$ROOT_DIR/docker/lib/entrypoint_helpers.sh'; write_proxy_ca_profile '$profile_dir'"
 assert_false "stale profile removed when no vars set" test -f "$profile_file"
 
 # The su whitelist covers both proxy and CA variables.
 assert_true "su whitelist includes proxy vars" bash -c "source '$ROOT_DIR/docker/lib/entrypoint_helpers.sh'; case \",\$PROXY_CA_ENV_VARS,\" in *,HTTPS_PROXY,*) exit 0;; *) exit 1;; esac"
 assert_true "su whitelist includes CA vars" bash -c "source '$ROOT_DIR/docker/lib/entrypoint_helpers.sh'; case \",\$PROXY_CA_ENV_VARS,\" in *,NODE_EXTRA_CA_CERTS,*) exit 0;; *) exit 1;; esac"
+assert_true "su whitelist includes Codex CA var" bash -c "source '$ROOT_DIR/docker/lib/entrypoint_helpers.sh'; case \",\$PROXY_CA_ENV_VARS,\" in *,CODEX_CA_CERTIFICATE,*) exit 0;; *) exit 1;; esac"
 
 # su_preserving_env passes the whitelist to a su that supports -w, and preserves
 # the value across a (stubbed) login-shell reset.


### PR DESCRIPTION
## Summary

- install the distribution bubblewrap package required by current Codex Linux/WSL2 sandboxing
- allow nested unprivileged namespaces by disabling Docker's default seccomp profile while retaining the existing restricted capability set
- point Codex HTTPS, login, and WebSocket clients at Ubuntu's system/custom CA bundle
- preserve the Codex CA setting across login shells, tool installation, SSH sessions, and cron
- add structural, helper, and disposable-container smoke coverage

## Why

Current Codex releases use bubblewrap for the Linux sandbox. In the existing image, bubblewrap is absent and Docker's default seccomp policy prevents the required nested namespace creation.

Codex also uses CODEX_CA_CERTIFICATE for HTTPS and secure WebSocket trust. Without an explicit bundle, WebSocket setup can fail with UnknownIssuer and fall back to HTTPS even though standard container TLS clients work.

The seccomp change is intentional and scoped to this development container. The service does not gain privileged mode, SYS_ADMIN, or Docker socket access; Docker capabilities remain restricted and bubblewrap applies Codex's inner workspace sandbox.

## Verification

- all shell test suites pass (185 assertions total after the new regressions)
- blocking ShellCheck passes for every shell script under docker/ and tests/
- git diff --check passes
- verified against Codex 0.144.6 that CODEX_CA_CERTIFICATE=/etc/ssl/certs/ca-certificates.crt removes the WebSocket UnknownIssuer failure
- Docker smoke CI now asserts that bubblewrap can launch and that the Codex CA bundle exists

The full Docker image build and nested namespace probe are left to the repository's disposable-container CI because the development container does not expose a Docker daemon.
